### PR TITLE
Add ESC5a (Access-Based) Detections

### DIFF
--- a/Classes/LS2AdcsObject.ps1
+++ b/Classes/LS2AdcsObject.ps1
@@ -43,10 +43,10 @@ class LS2AdcsObject {
     [Nullable[bool]]$AnyPurposeEKUExist
     [Nullable[bool]]$DangerousEnrollee
     [Nullable[bool]]$LowPrivilegeEnrollee
-    [string[]]$DangerousTemplateEditor
-    [string[]]$DangerousTemplateEditorNames
-    [string[]]$LowPrivilegeTemplateEditor
-    [string[]]$LowPrivilegeTemplateEditorNames
+    [string[]]$DangerousEditor
+    [string[]]$DangerousEditorNames
+    [string[]]$LowPrivilegeEditor
+    [string[]]$LowPrivilegeEditorNames
     [Nullable[bool]]$ManagerApprovalNotRequired
     [Nullable[bool]]$AuthorizedSignatureNotRequired
     [Nullable[bool]]$Enabled
@@ -120,10 +120,10 @@ class LS2AdcsObject {
         $this.AnyPurposeEKUExist = $null
         $this.DangerousEnrollee = $null
         $this.LowPrivilegeEnrollee = $null
-        $this.DangerousTemplateEditor = @()
-        $this.DangerousTemplateEditorNames = @()
-        $this.LowPrivilegeTemplateEditor = @()
-        $this.LowPrivilegeTemplateEditorNames = @()
+        $this.DangerousEditor = @()
+        $this.DangerousEditorNames = @()
+        $this.LowPrivilegeEditor = @()
+        $this.LowPrivilegeEditorNames = @()
         $this.ManagerApprovalNotRequired = $null
         $this.AuthorizedSignatureNotRequired = $null
         $this.Enabled = $null

--- a/Private/Test/Test-IsDangerousAce.ps1
+++ b/Private/Test/Test-IsDangerousAce.ps1
@@ -93,7 +93,6 @@ function Test-IsDangerousAce {
         [System.DirectoryServices.ActiveDirectoryAccessRule[]]$Ace,
         
         [Parameter(Mandatory)]
-        [ValidateSet('pKICertificateTemplate', 'pKIEnrollmentService', 'certificationAuthority', 'container', 'computer')]
         [string]$ObjectClass
     )
 

--- a/Public/Invoke-Locksmith2.ps1
+++ b/Public/Invoke-Locksmith2.ps1
@@ -117,8 +117,8 @@ function Invoke-Locksmith2 {
         Set-NoSecurityExtension |
         Set-DangerousEnrollee |
         Set-LowPrivilegeEnrollee |
-        Set-DangerousTemplateEditor |
-        Set-LowPrivilegeTemplateEditor |
+        Set-DangerousEditor |
+        Set-LowPrivilegeEditor |
         Set-ManagerApprovalNotRequired |
         Set-AuthorizedSignatureNotRequired |
         Set-TemplateEnabled |
@@ -149,7 +149,10 @@ function Invoke-Locksmith2 {
         $otherObjectCount = @($OtherObjects).Count
         Write-Verbose "Processing $otherObjectCount infrastructure object(s)..."
         
-        $OtherObjects = $OtherObjects | Set-HasNonStandardOwner
+        $OtherObjects = $OtherObjects | 
+        Set-DangerousEditor |
+        Set-LowPrivilegeEditor |
+        Set-HasNonStandardOwner
         
         Write-Verbose "Audit complete. Store statistics:"
         Write-Verbose "  - Principals stored: $($script:PrincipalStore.Count)"
@@ -202,6 +205,10 @@ function Invoke-Locksmith2 {
         Write-Verbose "Checking for ESC16 (Disabled Security Extension)..."
         [array]$ESC16Issues = Find-LS2VulnerableCA -Technique ESC16
         Write-Verbose "Found $(Get-IssueCount -Technique 'ESC16') ESC16 issue(s)"
+        
+        Write-Verbose "Checking for ESC5a (Vulnerable PKI Object Access Control)..."
+        [array]$ESC5aIssues = Find-LS2VulnerableObject -Technique ESC5a
+        Write-Verbose "Found $(Get-IssueCount -Technique 'ESC5a') ESC5a issue(s)"
         
         Write-Verbose "Checking for ESC5o (Vulnerable PKI Object Ownership)..."
         [array]$ESC5oIssues = Find-LS2VulnerableObject -Technique ESC5o


### PR DESCRIPTION
Implements ESC5a (Vulnerable PKI Object Access Control) detection and consolidates duplicate editor detection functions.

**Changes**
- Added ESC5a detection for write permissions on PKI infrastructure objects (containers, CAs, OIDs, etc.)
- Consolidated editor detection: `Set-DangerousEditor` and `Set-LowPrivilegeEditor` now work with all AD CS objects
- Unified class properties: `DangerousEditor`/`LowPrivilegeEditor` replace separate Template/PKIObject variants
- Removed ValidateSet restriction from `Test-IsDangerousAce` ObjectClass parameter

**Files Changed**
- 7 files: +256, -64 lines
- Renamed Set-Dangerous/LowPrivilegeTemplateEditor → Set-Dangerous/LowPrivilegeEditor
- Added ESC5a definition to ESCDefinitions.psd1
- Updated Find-LS2VulnerableObject and Invoke-Locksmith2