### PR TITLE
Fix/improve sid resolution

### DIFF
--- a/Private/Convert/Resolve-Principal.ps1
+++ b/Private/Convert/Resolve-Principal.ps1
@@ -97,7 +97,13 @@ function Resolve-Principal {
         if ($script:PrincipalStore.ContainsKey($sidString)) {
             $storedPrincipal = $script:PrincipalStore[$sidString]
             Write-Verbose "Store HIT: Found stored principal for SID '$sidString': $($storedPrincipal.distinguishedName)"
-            
+
+            # Well-known principals (e.g., Everyone, Authenticated Users) have no DN
+            if ($null -eq $storedPrincipal.distinguishedName) {
+                Write-Verbose "Well-known principal '$sidString' has no DN. Returning null."
+                return $null
+            }
+
             # Create fresh DirectoryEntry from stored DN
             $objectPath = "LDAP://$script:Server/$($storedPrincipal.distinguishedName)"
             $objectEntry = New-AuthenticatedDirectoryEntry -Path $objectPath

--- a/Private/Initialize/Initialize-AdcsObjectStore.ps1
+++ b/Private/Initialize/Initialize-AdcsObjectStore.ps1
@@ -79,6 +79,7 @@ function Initialize-AdcsObjectStore {
         Set-ManagerApprovalNotRequired |
         Set-AuthorizedSignatureNotRequired |
         Set-TemplateEnabled |
+        Set-Owner |
         Set-HasNonStandardOwner
         
         # Process Certification Authorities
@@ -97,6 +98,7 @@ function Initialize-AdcsObjectStore {
         Set-LowPrivilegeCAAdministrator |
         Set-DangerousCACertificateManager |
         Set-LowPrivilegeCACertificateManager |
+        Set-Owner |
         Set-HasNonStandardOwner
         
         # Process all other infrastructure objects for non-standard owners
@@ -110,6 +112,7 @@ function Initialize-AdcsObjectStore {
         $OtherObjects = $OtherObjects | 
         Set-DangerousEditor |
         Set-LowPrivilegeEditor |
+        Set-Owner |
         Set-HasNonStandardOwner
         
         Write-Verbose "AdcsObjectStore initialization complete. Statistics:"

--- a/Private/Set/Set-Owner.ps1
+++ b/Private/Set/Set-Owner.ps1
@@ -1,0 +1,141 @@
+function Set-Owner {
+    <#
+        .SYNOPSIS
+        Normalizes and resolves owner identity references for AD CS objects.
+
+        .DESCRIPTION
+        Examines the Owner property of AD CS objects and ensures consistent SID resolution
+        by calling Resolve-Principal to populate the PrincipalStore cache. This enables
+        downstream vulnerability detection functions (ESC4o, ESC5o) to consistently resolve
+        owner identities to human-readable names.
+        
+        The Owner property from ObjectSecurity.Owner can return inconsistent formats:
+        - DOMAIN\User (resolved NTAccount)
+        - S-1-5-21-... (raw SID string)
+        - O:S-1-5-21-... (SDDL format)
+        
+        This function extracts the SID, calls Resolve-Principal to cache the principal,
+        and normalizes the Owner property to a consistent SID string format that can be
+        reliably resolved later via Convert-IdentityReferenceToNTAccount.
+        
+        This is a critical preprocessing step for ESC4o and ESC5o vulnerability detection,
+        ensuring that owner identities can be consistently resolved regardless of the
+        format returned by the .NET ObjectSecurity.Owner property.
+
+        .PARAMETER AdcsObject
+        One or more LS2AdcsObject instances representing AD CS objects.
+
+        .INPUTS
+        LS2AdcsObject[]
+        You can pipe LS2AdcsObject instances to this function.
+
+        .OUTPUTS
+        LS2AdcsObject[]
+        Returns the input objects with normalized Owner properties.
+
+        .EXAMPLE
+        $templates = $script:AdcsObjectStore.Values | 
+            Where-Object { $_.objectClass -contains 'pKICertificateTemplate' }
+        $templates | Set-Owner
+        Normalizes owner identities for all certificate templates.
+
+        .EXAMPLE
+        $script:AdcsObjectStore.Values | Set-Owner
+        Normalizes owner identities for all AD CS objects in the store.
+
+        .NOTES
+        This function mirrors the ACE resolution pattern used in Set-DangerousEditor,
+        Set-LowPrivilegeEnrollee, etc., by proactively calling Resolve-Principal to
+        populate PrincipalStore before owner names are needed for display.
+        
+        Run this function in the Initialize-AdcsObjectStore pipeline after
+        Initialize-PrincipalDefinitions has completed and PrincipalStore is ready.
+    #>
+    [CmdletBinding()]
+    [OutputType([LS2AdcsObject[]])]
+    param (
+        [Parameter(Mandatory, ValueFromPipeline)]
+        [LS2AdcsObject[]]$AdcsObject
+    )
+
+    #requires -Version 5.1
+
+    begin {
+        Write-Verbose "Normalizing owner identities for AD CS objects..."
+    }
+
+    process {
+        $AdcsObject | ForEach-Object {
+            try {
+                $objectName = if ($_.displayName) {
+                    $_.displayName
+                } elseif ($_.Name) {
+                    $_.Name
+                } else {
+                    $_.DistinguishedName
+                }
+                Write-Verbose "Processing owner for: $objectName"
+                
+                $owner = $_.Owner
+                
+                if (-not $owner) {
+                    Write-Verbose "No owner found for object: $objectName"
+                    return $_
+                }
+                
+                # Extract SID from owner string (handles raw SID, SDDL format, or NTAccount)
+                $ownerSid = $null
+                
+                if ($owner -match '^(?:O:)?(S-1-[\d-]+)') {
+                    # Owner is already a SID (with or without SDDL prefix)
+                    try {
+                        $ownerSid = [System.Security.Principal.SecurityIdentifier]::new($Matches[1])
+                        Write-Verbose "Owner is SID format: $($ownerSid.Value)"
+                    } catch {
+                        Write-Warning "Invalid SID format for owner '$owner' on object '$objectName': $_"
+                    }
+                } else {
+                    # Owner is in NTAccount format (DOMAIN\User) - convert to SID
+                    try {
+                        $ntAccount = [System.Security.Principal.NTAccount]::new($owner)
+                        $ownerSid = $ntAccount.Translate([System.Security.Principal.SecurityIdentifier])
+                        Write-Verbose "Converted NTAccount '$owner' to SID: $($ownerSid.Value)"
+                    } catch {
+                        Write-Warning "Could not translate NTAccount '$owner' to SID for object '$objectName': $_"
+                    }
+                }
+                
+                # If we successfully extracted a SID, resolve it to populate PrincipalStore
+                if ($ownerSid) {
+                    Write-Verbose "Resolving owner SID to populate PrincipalStore: $($ownerSid.Value)"
+                    $null = $ownerSid | Resolve-Principal
+                    
+                    # Normalize the Owner property to the SID string
+                    # This ensures downstream code can reliably convert it via PrincipalStore
+                    $_.Owner = $ownerSid.Value
+                    
+                    Write-Verbose "Normalized owner to SID: $($ownerSid.Value)"
+                }
+                
+                # Return the modified object
+                $_
+                
+            } catch {
+                $errorRecord = [System.Management.Automation.ErrorRecord]::new(
+                    $_.Exception,
+                    'OwnerResolutionFailed',
+                    [System.Management.Automation.ErrorCategory]::InvalidOperation,
+                    $_
+                )
+                $PSCmdlet.WriteError($errorRecord)
+                
+                # Still return the object even if processing failed
+                $_
+            }
+        }
+    }
+
+    end {
+        Write-Verbose "Owner normalization complete."
+    }
+}

--- a/Public/Find-LS2VulnerableObject.ps1
+++ b/Public/Find-LS2VulnerableObject.ps1
@@ -215,17 +215,20 @@ function Find-LS2VulnerableObject {
                     # Get actual rights from ACE
                     $activeDirectoryRights = $ace.ActiveDirectoryRights
                     
+                    # Resolve IdentityReference to NTAccount format (SID → DOMAIN\Name)
+                    $identityReferenceName = ($ace.IdentityReference | Convert-IdentityReferenceToNTAccount).Value
+
                     # Expand issue template with variables
                     $issueText = ($config.IssueTemplate -join '') `
                         -replace '\$\(ObjectName\)', $objectName `
                         -replace '\$\(ObjectType\)', $objectType `
-                        -replace '\$\(IdentityReference\)', $ace.IdentityReference `
+                        -replace '\$\(IdentityReference\)', $identityReferenceName `
                         -replace '\$\(ActiveDirectoryRights\)', $activeDirectoryRights
                     
                     # Expand fix script template with variables
                     $fixScript = ($config.FixTemplate -join "`n") `
                         -replace '\$\(DistinguishedName\)', $object.distinguishedName `
-                        -replace '\$\(IdentityReference\)', $ace.IdentityReference
+                        -replace '\$\(IdentityReference\)', $identityReferenceName
                     
                     # Expand revert script template with variables
                     $revertScript = ($config.RevertTemplate -join "`n") `
@@ -262,7 +265,7 @@ function Find-LS2VulnerableObject {
                             Name                     = $objectName
                             DistinguishedName        = $object.distinguishedName
                             ObjectClass              = $vulnerableObjectClass
-                            IdentityReference        = $ace.IdentityReference
+                            IdentityReference        = $identityReferenceName
                             IdentityReferenceSID     = $editorSid
                             IdentityReferenceClass   = $principalObjectClass
                             ActiveDirectoryRights    = $activeDirectoryRights
@@ -349,8 +352,13 @@ function Find-LS2VulnerableObject {
         }
         
         $owner = if ($object.Owner) { $object.Owner } else { 'Unknown' }
-        
-        Write-Verbose "  Checking object: $objectName (owned by $owner)"
+
+        # Resolve owner SID to NTAccount format if needed (handles bare SID or O:SID SDDL format)
+        $ownerToDisplay = if ($owner -match '^(?:O:)?(S-1-[\d-]+)') {
+            ([System.Security.Principal.SecurityIdentifier]::new($Matches[1]) | Convert-IdentityReferenceToNTAccount).Value
+        } else { $owner }
+
+        Write-Verbose "  Checking object: $objectName (owned by $ownerToDisplay)"
         
         $issueCount++
         
@@ -374,7 +382,7 @@ function Find-LS2VulnerableObject {
         $issueText = ($config.IssueTemplate -join '') `
             -replace '\$\(ObjectName\)', $objectName `
             -replace '\$\(ObjectType\)', $objectType `
-            -replace '\$\(Owner\)', $owner
+            -replace '\$\(Owner\)', $ownerToDisplay
 
         # Expand fix script template with variables
         $fixScript = ($config.FixTemplate -join "`n") `
@@ -383,7 +391,7 @@ function Find-LS2VulnerableObject {
         # Expand revert script template with variables
         $revertScript = ($config.RevertTemplate -join "`n") `
             -replace '\$\(DistinguishedName\)', $object.distinguishedName `
-            -replace '\$\(OriginalOwner\)', $owner
+            -replace '\$\(OriginalOwner\)', $ownerToDisplay
 
         # Get object's objectClass (primary class)
         $vulnerableObjectClass = if ($object.objectClass -is [array]) {
@@ -399,7 +407,7 @@ function Find-LS2VulnerableObject {
                 Name                = $objectName
                 DistinguishedName   = $object.distinguishedName
                 ObjectClass         = $vulnerableObjectClass
-                Owner               = $owner
+                Owner               = $ownerToDisplay
                 HasNonStandardOwner = $true
                 Issue               = $issueText
                 Fix                 = $fixScript

--- a/Public/Find-LS2VulnerableTemplate.ps1
+++ b/Public/Find-LS2VulnerableTemplate.ps1
@@ -195,15 +195,18 @@ function Find-LS2VulnerableTemplate {
                     $config.RevertTemplate
                 }
 
+                # Resolve IdentityReference to NTAccount format (SID → DOMAIN\Name)
+                $identityReferenceName = ($ace.IdentityReference | Convert-IdentityReferenceToNTAccount).Value
+
                 # Expand template variables in Issue, Fix, and Revert strings
                 $issueText = $issueTemplate `
-                    -replace '\$\(IdentityReference\)', $ace.IdentityReference `
+                    -replace '\$\(IdentityReference\)', $identityReferenceName `
                     -replace '\$\(TemplateName\)', $template.Name `
                     -replace '\$\(ActiveDirectoryRights\)', $ace.ActiveDirectoryRights
                 
                 $fixScript = $fixTemplate `
                     -replace '\$\(DistinguishedName\)', $template.distinguishedName `
-                    -replace '\$\(IdentityReference\)', $ace.IdentityReference
+                    -replace '\$\(IdentityReference\)', $identityReferenceName
                 
                 $revertScript = $revertTemplate `
                     -replace '\$\(DistinguishedName\)', $template.distinguishedName
@@ -233,7 +236,7 @@ function Find-LS2VulnerableTemplate {
                     Name                   = $template.Name
                     DistinguishedName      = $template.distinguishedName
                     ObjectClass            = 'pKICertificateTemplate'
-                    IdentityReference      = $ace.IdentityReference
+                    IdentityReference      = $identityReferenceName
                     IdentityReferenceSID   = $editorSid
                     IdentityReferenceClass = $principalObjectClass
                     ActiveDirectoryRights  = $ace.ActiveDirectoryRights
@@ -282,6 +285,11 @@ function Find-LS2VulnerableTemplate {
             $templateName = if ($template.displayName) { $template.displayName } else { $template.Name }
             $owner = if ($template.Owner) { $template.Owner } else { 'Unknown' }
 
+            # Resolve owner SID to NTAccount format if needed (handles bare SID or O:SID SDDL format)
+            $ownerToDisplay = if ($owner -match '^(?:O:)?(S-1-[\d-]+)') {
+                ([System.Security.Principal.SecurityIdentifier]::new($Matches[1]) | Convert-IdentityReferenceToNTAccount).Value
+            } else { $owner }
+
             Write-Verbose "  Checking template: $templateName"
 
             # Get domain/forest name from DN
@@ -290,14 +298,14 @@ function Find-LS2VulnerableTemplate {
             # Create issue using template expansion
             $issueText = ($config.IssueTemplate -join '') `
                 -replace '\$\(TemplateName\)', $templateName `
-                -replace '\$\(Owner\)', $owner
+                -replace '\$\(Owner\)', $ownerToDisplay
 
             $fixScript = ($config.FixTemplate -join "`n") `
                 -replace '\$\(DistinguishedName\)', $template.distinguishedName
 
             $revertScript = ($config.RevertTemplate -join "`n") `
                 -replace '\$\(DistinguishedName\)', $template.distinguishedName `
-                -replace '\$\(OriginalOwner\)', $owner
+                -replace '\$\(OriginalOwner\)', $ownerToDisplay
 
             # Create issue object
             $issue = [LS2Issue]::new(@{
@@ -306,7 +314,7 @@ function Find-LS2VulnerableTemplate {
                     Name                = $templateName
                     DistinguishedName   = $template.distinguishedName
                     ObjectClass         = 'pKICertificateTemplate'
-                    Owner               = $owner
+                    Owner               = $ownerToDisplay
                     HasNonStandardOwner = $true
                     Enabled             = $template.Enabled
                     EnabledOn           = $template.EnabledOn
@@ -409,9 +417,12 @@ function Find-LS2VulnerableTemplate {
                 $config.RevertTemplate
             }
 
+            # Resolve IdentityReference to NTAccount format (SID → DOMAIN\Name)
+            $identityReferenceName = ($ace.IdentityReference | Convert-IdentityReferenceToNTAccount).Value
+
             # Expand template variables in Issue, Fix, and Revert strings
             $issueText = $issueTemplate `
-                -replace '\$\(IdentityReference\)', $ace.IdentityReference `
+                -replace '\$\(IdentityReference\)', $identityReferenceName `
                 -replace '\$\(TemplateName\)', $template.Name
             
             $fixScript = $fixTemplate `
@@ -426,7 +437,7 @@ function Find-LS2VulnerableTemplate {
                 Forest                = $forestName
                 Name                  = $template.Name
                 DistinguishedName     = $template.distinguishedName
-                IdentityReference     = $ace.IdentityReference
+                IdentityReference     = $identityReferenceName
                 IdentityReferenceSID  = $enrolleeSid
                 ActiveDirectoryRights = $ace.ActiveDirectoryRights
                 Enabled               = $template.Enabled


### PR DESCRIPTION
- Create Set-Owner.ps1 to normalize owner identities via Resolve-Principal
- Add Set-Owner to template, CA, and infrastructure object pipelines
- Ensures owner SIDs are cached in PrincipalStore before vulnerability detection
- Fixes inconsistent owner display (DOMAIN\User vs S-1-5-21-... vs O:S-1-5-21-...)
- Mirrors ACE resolution pattern used in Set-DangerousEditor and Set-LowPrivilegeEnrollee