### PR TITLE
fix(resolution): fix SID-shaped identity resolution failures and populate missing issue metadata

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -108,7 +108,7 @@ Build-Module -ModuleName 'Locksmith2' {
 
     # configuration for documentation, at the same time it enables documentation processing
     New-ConfigurationDocumentation -Enable:$false -StartClean -UpdateWhenNew -PathReadme 'Docs\Readme.md' -Path 'Docs'
-
+    New-ConfigurationInformation -IncludeAll 'Private\Data'
     New-ConfigurationImportModule -ImportSelf -ImportRequiredModules
 
     New-ConfigurationBuild -Enable:$true -SignModule:$false -DeleteTargetModuleBeforeBuild -MergeModuleOnBuild -MergeFunctionsFromApprovedModules -DoNotAttemptToFixRelativePaths -UseWildcardForFunctions

--- a/Locksmith2.psd1
+++ b/Locksmith2.psd1
@@ -8,11 +8,11 @@
     Description          = 'An AD CS toolkit for AD Admins, Defensive Security Professionals, and Filthy Red Teamers'
     FunctionsToExport    = @('*')
     GUID                 = 'e32f7d0d-2b10-4db2-b776-a193958e3d69'
-    ModuleVersion        = '2026.1.4.1152'
+    ModuleVersion        = '2026.3.26.1044'
     PowerShellVersion    = '5.1'
     PrivateData          = @{
         PSData = @{
-            ExternalModuleDependencies = @('Microsoft.PowerShell.Utility', 'Microsoft.PowerShell.Archive', 'Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Security', 'PowerShellGet', 'CimCmdlets')
+            ExternalModuleDependencies = @('Microsoft.PowerShell.Utility', 'Microsoft.PowerShell.Archive', 'Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Security', 'PowerShellGet', 'CimCmdlets', 'PSWriteHTML')
             ProjectUri                 = 'https://github.com/jakehildreth/Locksmith2'
             RequireLicenseAcceptance   = $false
             Tags                       = @('Locksmith', 'Locksmith2', 'ActiveDirectory', 'ADCS', 'CA', 'Certificate', 'CertificateAuthority', 'CertificateServices', 'PKI', 'X509', 'Windows')
@@ -21,8 +21,8 @@
     RequiredModules      = @(@{
             Guid          = '357478c8-bec5-4ee3-bc2e-21d2357b2dd1'
             ModuleName    = 'PSCertutil'
-            ModuleVersion = '0.0.2'
-        }, 'Microsoft.PowerShell.Utility', 'Microsoft.PowerShell.Archive', 'Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Security', 'PowerShellGet', 'CimCmdlets')
+            ModuleVersion = '0.0.3'
+        }, 'Microsoft.PowerShell.Utility', 'Microsoft.PowerShell.Archive', 'Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Security', 'PowerShellGet', 'CimCmdlets', 'PSWriteHTML')
     RootModule           = 'Locksmith2.psm1'
-    ScriptsToProcess     = @('Classes\LS2Principal.ps1', 'Classes\LS2AdcsObject.ps1')
+    ScriptsToProcess     = @('Classes\LS2Principal.ps1', 'Classes\LS2AdcsObject.ps1', '.\Classes\LS2Issue.ps1')
 }

--- a/Private/Convert/Convert-IdentityReferenceToNTAccount.ps1
+++ b/Private/Convert/Convert-IdentityReferenceToNTAccount.ps1
@@ -66,13 +66,28 @@ function Convert-IdentityReferenceToNTAccount {
     )
 
     process {
+        $identityValue = $SecurityIdentifier.Value
+
+        # Some ACL APIs can surface SID-shaped values wrapped in non-SID IdentityReference types.
+        # Normalize them early so we use SID resolution instead of treating them as NTAccount names.
+        if ($SecurityIdentifier -isnot [System.Security.Principal.SecurityIdentifier] -and $identityValue -match '^(?:O:)?(S-1-[\d-]+)$') {
+            try {
+                $SecurityIdentifier = [System.Security.Principal.SecurityIdentifier]::new($Matches[1])
+                $identityValue = $SecurityIdentifier.Value
+                Write-Verbose "Normalized SID-shaped identity reference '$identityValue' to SecurityIdentifier"
+            } catch {
+                Write-Warning "Could not parse SID-shaped identity reference '$identityValue': $_"
+                return $SecurityIdentifier
+            }
+        }
+
         # If already an NTAccount, return it
         if ($SecurityIdentifier -is [System.Security.Principal.NTAccount]) {
             return $SecurityIdentifier
         }
 
         # Check PrincipalStore first (if it exists) - it has the NTAccount name already
-        $sidString = $SecurityIdentifier.Value
+        $sidString = $identityValue
         if ($script:PrincipalStore -and $script:PrincipalStore.ContainsKey($sidString)) {
             $storedPrincipal = $script:PrincipalStore[$sidString]
             if ($storedPrincipal.ntAccountName) {
@@ -96,9 +111,6 @@ function Convert-IdentityReferenceToNTAccount {
         }
 
         try {
-            # Get the SID string
-            $sidString = $SecurityIdentifier.Value
-
             # First try Global Catalog search for forest-wide lookup
             Write-Verbose "Attempting Global Catalog search for SID '$sidString'"
             $gcSearcher = New-GCSearcher -Filter "(objectSid=$sidString)" -PropertiesToLoad @('distinguishedName', 'sAMAccountName')

--- a/Private/Convert/Convert-IdentityReferenceToSid.ps1
+++ b/Private/Convert/Convert-IdentityReferenceToSid.ps1
@@ -57,6 +57,21 @@ function Convert-IdentityReferenceToSid {
     )
 
     process {
+        $identityValue = $IdentityReference.Value
+
+        # Some ACL APIs can return SID-shaped values wrapped in non-SID IdentityReference types.
+        # Normalize them early so we do not perform bogus sAMAccountName LDAP lookups.
+        if ($IdentityReference -isnot [System.Security.Principal.SecurityIdentifier] -and $identityValue -match '^(?:O:)?(S-1-[\d-]+)$') {
+            try {
+                $IdentityReference = [System.Security.Principal.SecurityIdentifier]::new($Matches[1])
+                $identityValue = $IdentityReference.Value
+                Write-Verbose "Normalized SID-shaped identity reference '$identityValue' to SecurityIdentifier"
+            } catch {
+                Write-Warning "Could not parse SID-shaped identity reference '$identityValue': $_"
+                return $IdentityReference
+            }
+        }
+
         # If already a SID, return it
         if ($IdentityReference -is [System.Security.Principal.SecurityIdentifier]) {
             return $IdentityReference
@@ -65,9 +80,9 @@ function Convert-IdentityReferenceToSid {
         # Check PrincipalStore first (if it exists) - it has the SID already
         if ($script:PrincipalStore) {
             # Try to find by NTAccount value
-            $matchingPrincipal = $script:PrincipalStore.Values | Where-Object { $_.ntAccountName -eq $IdentityReference.Value } | Select-Object -First 1
+            $matchingPrincipal = $script:PrincipalStore.Values | Where-Object { $_.ntAccountName -eq $identityValue } | Select-Object -First 1
             if ($matchingPrincipal -and $matchingPrincipal.sid) {
-                Write-Verbose "PrincipalStore HIT for '$($IdentityReference.Value)' → SID: $($matchingPrincipal.sid)"
+                Write-Verbose "PrincipalStore HIT for '$identityValue' → SID: $($matchingPrincipal.sid)"
                 return [System.Security.Principal.SecurityIdentifier]::new($matchingPrincipal.sid)
             }
         }
@@ -88,7 +103,7 @@ function Convert-IdentityReferenceToSid {
 
         try {
             # Parse the NTAccount name
-            $ntAccountString = $IdentityReference.Value
+            $ntAccountString = $identityValue
             if ($ntAccountString -match '^(.+?)\\(.+)$') {
                 $samAccountName = $Matches[2]
             } else {

--- a/Private/Convert/Resolve-Principal.ps1
+++ b/Private/Convert/Resolve-Principal.ps1
@@ -73,6 +73,28 @@ function Resolve-Principal {
             Write-Warning "Could not convert IdentityReference to SID: $($IdentityReference.Value)"
             return $null
         }
+
+        if ($sidKey -isnot [System.Security.Principal.SecurityIdentifier]) {
+            $sidValue = if ($sidKey -is [string]) {
+                $sidKey
+            } elseif ($sidKey.PSObject.Properties['Value']) {
+                $sidKey.Value
+            } else {
+                $null
+            }
+
+            if ($sidValue -match '^(?:O:)?(S-1-[\d-]+)$') {
+                try {
+                    $sidKey = [System.Security.Principal.SecurityIdentifier]::new($Matches[1])
+                } catch {
+                    Write-Warning "Could not parse SID value '$sidValue' while resolving principal '$($IdentityReference.Value)': $_"
+                    return $null
+                }
+            } else {
+                Write-Warning "Could not convert IdentityReference '$($IdentityReference.Value)' to a SecurityIdentifier. Resolved type: $($sidKey.GetType().FullName)"
+                return $null
+            }
+        }
         
         $sidString = $sidKey.Value
         
@@ -195,7 +217,7 @@ function Resolve-Principal {
                 return $null
             }
         } catch {
-            Write-Warning "LDAP query failed for SID '$sidString': $_"
+            Write-Warning "Principal resolution failed for SID '$sidString': $_"
             return $null
         } finally {
             if ($searcher) { $searcher.Dispose() }

--- a/Public/Find-LS2VulnerableTemplate.ps1
+++ b/Public/Find-LS2VulnerableTemplate.ps1
@@ -431,14 +431,23 @@ function Find-LS2VulnerableTemplate {
             $revertScript = $revertTemplate `
                 -replace '\$\(DistinguishedName\)', $template.distinguishedName
 
+            # Get principal objectClass from PrincipalStore
+            $principalObjectClass = if ($script:PrincipalStore -and $script:PrincipalStore.ContainsKey($enrolleeSid)) {
+                $script:PrincipalStore[$enrolleeSid].objectClass
+            } else {
+                $null
+            }
+
             # Create LS2Issue object
             $issue = [LS2Issue]@{
                 Technique             = $technique
                 Forest                = $forestName
                 Name                  = $template.Name
                 DistinguishedName     = $template.distinguishedName
+                ObjectClass           = 'pKICertificateTemplate'
                 IdentityReference     = $identityReferenceName
                 IdentityReferenceSID  = $enrolleeSid
+                IdentityReferenceClass = $principalObjectClass
                 ActiveDirectoryRights = $ace.ActiveDirectoryRights
                 Enabled               = $template.Enabled
                 EnabledOn             = $template.EnabledOn


### PR DESCRIPTION
Some ACL APIs return SID-shaped strings wrapped in non-SecurityIdentifier types,
causing bogus LDAP lookups and silent principal resolution failures.

- Add early SID normalization to Convert-IdentityReferenceToSid and
  Convert-IdentityReferenceToNTAccount; handles O:-prefixed SID strings via
  capture group before any store lookup or LDAP query runs
- Add post-conversion SID guard in Resolve-Principal; parses non-SecurityIdentifier
  output from Convert-IdentityReferenceToSid before bailing with null
- Populate ObjectClass (pKICertificateTemplate) and IdentityReferenceClass
  (from PrincipalStore) on LS2Issue objects emitted by Find-LS2VulnerableTemplate
- Include Private\Data in packaged module via New-ConfigurationInformation in
  Build-Module.ps1; bump PSCertutil to 0.0.3, add PSWriteHTML dependency,
  add LS2Issue.ps1 to ScriptsToProcess