### PR TITLE
feat(ci): add prerelease publishing for non-main branches

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,6 @@ name: Build and Publish to PSGallery
 
 on:
   push:
-    branches: [ main ]
     paths:
       - 'Public/**'
       - 'Private/**'
@@ -46,13 +45,24 @@ jobs:
     #
     #     Write-Host "All tests passed!" -ForegroundColor Green
 
-    - name: Build and Publish to PowerShell Gallery
+    - name: Build and Publish (Release)
+      if: github.ref == 'refs/heads/main'
       shell: pwsh
       env:
         PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
       run: |
-        Write-Host "Building and publishing Locksmith2 module..." -ForegroundColor Cyan
+        Write-Host "Building and publishing Locksmith2 (release)..." -ForegroundColor Cyan
         ./Build/Build-Module.ps1 -PublishToPSGallery -PSGalleryAPIKey $env:PSGALLERY_API_KEY
+        Write-Host "Published successfully" -ForegroundColor Green
+
+    - name: Build and Publish (Prerelease)
+      if: github.ref != 'refs/heads/main'
+      shell: pwsh
+      env:
+        PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
+      run: |
+        Write-Host "Building and publishing Locksmith2 (prerelease)..." -ForegroundColor Cyan
+        ./Build/Build-Module.ps1 -PublishToPSGallery -PSGalleryAPIKey $env:PSGALLERY_API_KEY -Prerelease 'prerelease'
         Write-Host "Published successfully" -ForegroundColor Green
 
     - name: Get module version
@@ -61,5 +71,7 @@ jobs:
       run: |
         $manifest = Import-PowerShellDataFile ./Locksmith2.psd1
         $version = $manifest.ModuleVersion
-        echo "version=$version" >> $env:GITHUB_OUTPUT
-        Write-Host "Module version: $version" -ForegroundColor Green
+        $prerelease = $manifest.PrivateData.PSData.Prerelease
+        $fullVersion = if ($prerelease) { "$version-$prerelease" } else { $version }
+        echo "version=$fullVersion" >> $env:GITHUB_OUTPUT
+        Write-Host "Module version: $fullVersion" -ForegroundColor Green

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,7 +62,7 @@ jobs:
         PSGALLERY_API_KEY: ${{ secrets.PSGALLERY_API_KEY }}
       run: |
         Write-Host "Building and publishing Locksmith2 (prerelease)..." -ForegroundColor Cyan
-        ./Build/Build-Module.ps1 -PublishToPSGallery -PSGalleryAPIKey $env:PSGALLERY_API_KEY -Prerelease 'prerelease'
+        ./Build/Build-Module.ps1 -PublishToPSGallery -PSGalleryAPIKey $env:PSGALLERY_API_KEY -Prerelease 'pre'
         Write-Host "Published successfully" -ForegroundColor Green
 
     - name: Get module version

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -28,8 +28,17 @@ $CopyrightYear = if ($Calver) { $CalVer.Split('.')[0] } else { (Get-Date -Format
 
 Build-Module -ModuleName 'Locksmith2' {
     # Usual defaults as per standard module
+    # PSGallery requires exactly 3-part versions when using a Prerelease string,
+    # so fold the time component into the prerelease tag for non-main builds.
+    if ($Prerelease) {
+        $moduleVersion = if ($CalVer) { $CalVer } else { (Get-Date -Format yyyy.M.d) }
+        $timeSuffix = Get-Date -Format Hmm
+        $prereleaseTag = "$Prerelease$timeSuffix"
+    } else {
+        $moduleVersion = if ($CalVer) { $CalVer } else { (Get-Date -Format yyyy.M.d.Hmm) }
+    }
     $Manifest = [ordered] @{
-        ModuleVersion        = if ($Calver) { $CalVer } else { (Get-Date -Format yyyy.M.d.Hmm) }
+        ModuleVersion        = $moduleVersion
         CompatiblePSEditions = @('Desktop', 'Core')
         GUID                 = 'e32f7d0d-2b10-4db2-b776-a193958e3d69'
         Author               = 'Jake Hildreth'
@@ -40,8 +49,8 @@ Build-Module -ModuleName 'Locksmith2' {
         PowerShellVersion    = '5.1'
         Tags                 = @('Locksmith', 'Locksmith2', 'ActiveDirectory', 'ADCS', 'CA', 'Certificate', 'CertificateAuthority', 'CertificateServices', 'PKI', 'X509', 'Windows')
     }
-    if ($Prerelease) {
-        $Manifest['Prerelease'] = $Prerelease
+    if ($prereleaseTag) {
+        $Manifest['Prerelease'] = $prereleaseTag
     }
     New-ConfigurationManifest @Manifest
 

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -28,15 +28,9 @@ $CopyrightYear = if ($Calver) { $CalVer.Split('.')[0] } else { (Get-Date -Format
 
 Build-Module -ModuleName 'Locksmith2' {
     # Usual defaults as per standard module
-    # PSGallery requires exactly 3-part versions when using a Prerelease string,
-    # so fold the time component into the prerelease tag for non-main builds.
-    if ($Prerelease) {
-        $moduleVersion = if ($CalVer) { $CalVer } else { (Get-Date -Format yyyy.M.d) }
-        $timeSuffix = Get-Date -Format Hmm
-        $prereleaseTag = "$Prerelease$timeSuffix"
-    } else {
-        $moduleVersion = if ($CalVer) { $CalVer } else { (Get-Date -Format yyyy.M.d.Hmm) }
-    }
+    # Always use 3-part CalVer: yyyy.M.dHHmm (e.g., 2026.4.70225)
+    # Prerelease builds append -pre to the version string.
+    $moduleVersion = if ($CalVer) { $CalVer } else { (Get-Date -Format 'yyyy.M.dHHmm') }
     $Manifest = [ordered] @{
         ModuleVersion        = $moduleVersion
         CompatiblePSEditions = @('Desktop', 'Core')
@@ -49,8 +43,8 @@ Build-Module -ModuleName 'Locksmith2' {
         PowerShellVersion    = '5.1'
         Tags                 = @('Locksmith', 'Locksmith2', 'ActiveDirectory', 'ADCS', 'CA', 'Certificate', 'CertificateAuthority', 'CertificateServices', 'PKI', 'X509', 'Windows')
     }
-    if ($prereleaseTag) {
-        $Manifest['Prerelease'] = $prereleaseTag
+    if ($Prerelease) {
+        $Manifest['Prerelease'] = $Prerelease
     }
     New-ConfigurationManifest @Manifest
 

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,6 +1,8 @@
 ﻿param (
     # A CalVer string if you need to manually override the default yyyy.M.d version string.
     [string]$CalVer,
+    # A prerelease tag to append to the module version (e.g., 'alpha', 'beta', 'rc1').
+    [string]$Prerelease,
     [switch]$PublishToPSGallery,
     [string]$PSGalleryAPIPath,
     [string]$PSGalleryAPIKey
@@ -37,6 +39,9 @@ Build-Module -ModuleName 'Locksmith2' {
         ProjectUri           = 'https://github.com/jakehildreth/Locksmith2'
         PowerShellVersion    = '5.1'
         Tags                 = @('Locksmith', 'Locksmith2', 'ActiveDirectory', 'ADCS', 'CA', 'Certificate', 'CertificateAuthority', 'CertificateServices', 'PKI', 'X509', 'Windows')
+    }
+    if ($Prerelease) {
+        $Manifest['Prerelease'] = $Prerelease
     }
     New-ConfigurationManifest @Manifest
 


### PR DESCRIPTION
- Modified .github/workflows/publish.yml to trigger on pushes to all branches, not just main
- Added conditional build steps: full release on main, prerelease on non-main branches
- Added -Prerelease parameter to Build/Build-Module.ps1 for passing prerelease tag to manifest
- Updated version output step to include prerelease suffix in reported version