### PR TITLE
feat(tests): Phase 0/1 Pester infrastructure and build reliability fixes

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -8,6 +8,25 @@
     [string]$PSGalleryAPIKey
 )
 
+# The VS Code PowerShell Extension pre-loads PSScriptAnalyzer into the host
+# process. PSPublishModule imports PSScriptAnalyzer internally, and loading a
+# second copy of its assembly into the same appdomain throws an assembly-already-
+# loaded error. Re-invoke in a clean pwsh -NoProfile child process to avoid it.
+if ($Host.Name -eq 'Visual Studio Code Host' -or
+    $null -ne [System.AppDomain]::CurrentDomain.GetAssemblies().Where({
+            $_.GetName().Name -eq 'Microsoft.Windows.PowerShell.ScriptAnalyzer'
+        }, 'First')[0]) {
+    Write-Host 'Re-invoking in a clean pwsh process to avoid PSScriptAnalyzer assembly conflict...'
+    $passThrough = @('-NoProfile', '-File', $PSCommandPath)
+    if ($CalVer) { $passThrough += '-CalVer'; $passThrough += $CalVer }
+    if ($Prerelease) { $passThrough += '-Prerelease'; $passThrough += $Prerelease }
+    if ($PublishToPSGallery) { $passThrough += '-PublishToPSGallery' }
+    if ($PSGalleryAPIPath) { $passThrough += '-PSGalleryAPIPath'; $passThrough += $PSGalleryAPIPath }
+    if ($PSGalleryAPIKey) { $passThrough += '-PSGalleryAPIKey'; $passThrough += $PSGalleryAPIKey }
+    & pwsh @passThrough
+    exit $LASTEXITCODE
+}
+
 if (Get-Module -Name 'PSPublishModule' -ListAvailable) {
     Write-Verbose 'PSPublishModule is installed.'
 } else {
@@ -104,14 +123,16 @@ Build-Module -ModuleName 'Locksmith2' {
 
         UseCorrectCasingEnable                      = $true
     }
-    # format PSD1 and PSM1 files when merging into a single file
+    # format PSM1 files when merging into a single file
     # enable formatting is not required as Configuration is provided
-    # New-ConfigurationFormat -ApplyTo 'OnMergePSM1', 'OnMergePSD1' -Sort None @ConfigurationFormat
-    # format PSD1 and PSM1 files within the module
+    # New-ConfigurationFormat -ApplyTo 'OnMergePSM1' -Sort None @ConfigurationFormat
+    # format PSM1 files within the module
     # enable formatting is required to make sure that formatting is applied (with default settings)
-    New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'DefaultPSM1' -EnableFormatting -Sort None
+    New-ConfigurationFormat -ApplyTo 'DefaultPSM1' -EnableFormatting -Sort None
     # when creating PSD1 use special style without comments and with only required parameters
-    New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
+    # DefaultPSD1 is intentionally excluded: PSPublishModule rewrites the source PSD1 during the
+    # build and produces mixed CRLF/LF endings, which causes PSScriptAnalyzer to throw.
+    New-ConfigurationFormat -ApplyTo 'OnMergePSD1' -PSD1Style 'Minimal'
 
     # configuration for documentation, at the same time it enables documentation processing
     New-ConfigurationDocumentation -Enable:$false -StartClean -UpdateWhenNew -PathReadme 'Docs\Readme.md' -Path 'Docs'

--- a/Locksmith2.Pester.config.ps1
+++ b/Locksmith2.Pester.config.ps1
@@ -1,0 +1,17 @@
+#requires -Version 5.1
+$config = New-PesterConfiguration
+$config.Run.Path = './Tests'
+$config.Run.Exit = $true
+$config.Output.Verbosity = 'Detailed'
+$config.Output.StackTraceVerbosity = 'Filtered'
+$config.Filter.Tag = @('Unit')
+$config.Filter.ExcludeTag = @('Integration')
+$config.CodeCoverage.Enabled = $true
+$config.CodeCoverage.Path = @('./Classes/*.ps1', './Private/**/*.ps1', './Public/*.ps1')
+$config.CodeCoverage.OutputFormat = 'JaCoCo'
+$config.CodeCoverage.OutputPath = './Tests/coverage.xml'
+$config.TestResult.Enabled = $true
+$config.TestResult.OutputFormat = 'NUnitXml'
+$config.TestResult.OutputPath = './Tests/testResults.xml'
+$config.Should.ErrorAction = 'Continue'
+return $config

--- a/Locksmith2.psd1
+++ b/Locksmith2.psd1
@@ -1,24 +1,24 @@
 ﻿@{
-    AliasesToExport      = @('*')
-    Author               = 'Jake Hildreth'
-    CmdletsToExport      = @()
-    CompanyName          = 'Gilmour Technologies Ltd'
-    CompatiblePSEditions = @('Desktop', 'Core')
-    Copyright            = '(c) 2024 - 2026. All rights reserved.'
-    Description          = 'An AD CS toolkit for AD Admins, Defensive Security Professionals, and Filthy Red Teamers'
-    FunctionsToExport    = @('*')
-    GUID                 = 'e32f7d0d-2b10-4db2-b776-a193958e3d69'
-    ModuleVersion        = '2026.4.6.1842'
-    PowerShellVersion    = '5.1'
-    PrivateData          = @{
-        PSData = @{
-            ExternalModuleDependencies = @('Microsoft.PowerShell.Utility', 'Microsoft.PowerShell.Archive', 'Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Security', 'PowerShellGet', 'CimCmdlets')
-            ProjectUri                 = 'https://github.com/jakehildreth/Locksmith2'
-            RequireLicenseAcceptance   = $false
-            Tags                       = @('Locksmith', 'Locksmith2', 'ActiveDirectory', 'ADCS', 'CA', 'Certificate', 'CertificateAuthority', 'CertificateServices', 'PKI', 'X509', 'Windows')
+    AliasesToExport=@('*')
+    Author='Jake Hildreth'
+    CmdletsToExport=@()
+    CompanyName='Gilmour Technologies Ltd'
+    CompatiblePSEditions=@('Desktop',        'Core')
+    Copyright='(c) 2024 - 2026. All rights reserved.'
+    Description='An AD CS toolkit for AD Admins, Defensive Security Professionals, and Filthy Red Teamers'
+    FunctionsToExport=@('*')
+    GUID='e32f7d0d-2b10-4db2-b776-a193958e3d69'
+    ModuleVersion='2026.5.41328'
+    PowerShellVersion='5.1'
+    PrivateData=@{
+        PSData=@{
+            ExternalModuleDependencies=@('Microsoft.PowerShell.Utility',                'Microsoft.PowerShell.Archive',                'Microsoft.PowerShell.Management',                'Microsoft.PowerShell.Security',                'PowerShellGet',                'CimCmdlets')
+            ProjectUri='https://github.com/jakehildreth/Locksmith2'
+            RequireLicenseAcceptance=$false
+            Tags=@('Locksmith',                'Locksmith2',                'ActiveDirectory',                'ADCS',                'CA',                'Certificate',                'CertificateAuthority',                'CertificateServices',                'PKI',                'X509',                'Windows')
         }
     }
-    RequiredModules      = @('Microsoft.PowerShell.Utility', 'Microsoft.PowerShell.Archive', 'Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Security', 'PowerShellGet', 'CimCmdlets')
-    RootModule           = 'Locksmith2.psm1'
-    ScriptsToProcess     = @('Classes\LS2Principal.ps1', 'Classes\LS2AdcsObject.ps1', '.\Classes\LS2Issue.ps1')
+    RequiredModules=@('Microsoft.PowerShell.Utility',        'Microsoft.PowerShell.Archive',        'Microsoft.PowerShell.Management',        'Microsoft.PowerShell.Security',        'PowerShellGet',        'CimCmdlets')
+    RootModule='Locksmith2.psm1'
+    ScriptsToProcess=@('Classes\LS2Principal.ps1',        'Classes\LS2AdcsObject.ps1',        '.\Classes\LS2Issue.ps1')
 }

--- a/Locksmith2.psd1
+++ b/Locksmith2.psd1
@@ -8,7 +8,7 @@
     Description='An AD CS toolkit for AD Admins, Defensive Security Professionals, and Filthy Red Teamers'
     FunctionsToExport=@('*')
     GUID='e32f7d0d-2b10-4db2-b776-a193958e3d69'
-    ModuleVersion='2026.5.41328'
+    ModuleVersion='2026.5.42004'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{

--- a/Tests/Classes/LS2AdcsObject.Tests.ps1
+++ b/Tests/Classes/LS2AdcsObject.Tests.ps1
@@ -1,0 +1,177 @@
+#requires -Version 5.1
+BeforeAll {
+    $ModuleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    Import-Module (Join-Path $ModuleRoot 'Tests' 'Shared' 'TestHelpers.psm1') -Force -ErrorAction Stop
+}
+
+Describe 'LS2AdcsObject class' -Tag 'Unit' {
+
+    Describe 'IsCertificateTemplate()' {
+        It 'should return true when SchemaClassName is pKICertificateTemplate' {
+            $obj = New-MockLS2AdcsObject
+            $obj.IsCertificateTemplate() | Should -BeTrue
+        }
+
+        It 'should return false when SchemaClassName is pKIEnrollmentService' {
+            $obj = New-MockLS2AdcsObject -Properties @{ SchemaClassName = 'pKIEnrollmentService' }
+            $obj.IsCertificateTemplate() | Should -BeFalse
+        }
+
+        It 'should return false when SchemaClassName is container' {
+            $obj = New-MockLS2AdcsObject -Properties @{ SchemaClassName = 'container' }
+            $obj.IsCertificateTemplate() | Should -BeFalse
+        }
+
+        It 'should return false when SchemaClassName is null' -Tag 'EdgeCase' {
+            $obj = New-MockLS2AdcsObject -Properties @{ SchemaClassName = $null }
+            $obj.IsCertificateTemplate() | Should -BeFalse
+        }
+    }
+
+    Describe 'IsCertificationAuthority()' {
+        It 'should return true when objectClass contains pKIEnrollmentService' {
+            $obj = New-MockLS2AdcsObject -Properties @{
+                objectClass     = @('top', 'pKIEnrollmentService')
+                SchemaClassName = 'pKIEnrollmentService'
+            }
+            $obj.IsCertificationAuthority() | Should -BeTrue
+        }
+
+        It 'should return false when objectClass does not contain pKIEnrollmentService' {
+            $obj = New-MockLS2AdcsObject
+            $obj.IsCertificationAuthority() | Should -BeFalse
+        }
+
+        It 'should return false for a container objectClass' {
+            $obj = New-MockLS2AdcsObject -Properties @{
+                objectClass     = @('top', 'container')
+                SchemaClassName = 'container'
+            }
+            $obj.IsCertificationAuthority() | Should -BeFalse
+        }
+
+        It 'should return false for an empty objectClass array' -Tag 'EdgeCase' {
+            $obj = New-MockLS2AdcsObject -Properties @{ objectClass = @() }
+            $obj.IsCertificationAuthority() | Should -BeFalse
+        }
+    }
+
+    Describe 'GetFriendlyName()' {
+        It 'should return displayName when it is set' {
+            $obj = New-MockLS2AdcsObject -Properties @{ displayName = 'My Display Name' }
+            $obj.GetFriendlyName() | Should -Be 'My Display Name'
+        }
+
+        It 'should return name when displayName is null' {
+            $obj = New-MockLS2AdcsObject -Properties @{
+                displayName = $null
+                name        = 'MyName'
+            }
+            $obj.GetFriendlyName() | Should -Be 'MyName'
+        }
+
+        It 'should return cn when displayName and name are null' {
+            $obj = New-MockLS2AdcsObject -Properties @{
+                displayName = $null
+                name        = $null
+                cn          = 'MyCN'
+            }
+            $obj.GetFriendlyName() | Should -Be 'MyCN'
+        }
+
+        It 'should return distinguishedName when displayName, name, and cn are all null' {
+            $obj = New-MockLS2AdcsObject -Properties @{
+                displayName       = $null
+                name              = $null
+                cn                = $null
+                distinguishedName = 'CN=Fallback,DC=contoso,DC=com'
+            }
+            $obj.GetFriendlyName() | Should -Be 'CN=Fallback,DC=contoso,DC=com'
+        }
+
+        It 'should prefer displayName over all other properties' {
+            $obj = New-MockLS2AdcsObject -Properties @{
+                displayName       = 'Winner'
+                name              = 'Loser1'
+                cn                = 'Loser2'
+                distinguishedName = 'CN=Loser3,DC=contoso,DC=com'
+            }
+            $obj.GetFriendlyName() | Should -Be 'Winner'
+        }
+    }
+
+    Describe 'Computed property read/write via GetUninitializedObject' {
+        It 'should allow SANAllowed to be set to $true and read back' {
+            $obj = New-MockLS2AdcsObject -Properties @{ SANAllowed = $true }
+            $obj.SANAllowed | Should -BeTrue
+        }
+
+        It 'should allow SANAllowed to be set to $false and read back' {
+            $obj = New-MockLS2AdcsObject -Properties @{ SANAllowed = $false }
+            $obj.SANAllowed | Should -BeFalse
+        }
+
+        It 'should allow AuthenticationEKUExist to be set and read back' {
+            $obj = New-MockLS2AdcsObject -Properties @{ AuthenticationEKUExist = $true }
+            $obj.AuthenticationEKUExist | Should -BeTrue
+        }
+
+        It 'should allow ManagerApprovalNotRequired to be set and read back' {
+            $obj = New-MockLS2AdcsObject -Properties @{ ManagerApprovalNotRequired = $false }
+            $obj.ManagerApprovalNotRequired | Should -BeFalse
+        }
+
+        It 'should allow DangerousEnrollee to be set as an array and read back' {
+            $obj = New-MockLS2AdcsObject -Properties @{ DangerousEnrollee = @('S-1-1-0', 'S-1-5-11') }
+            $obj.DangerousEnrollee | Should -Contain 'S-1-1-0'
+            $obj.DangerousEnrollee | Should -Contain 'S-1-5-11'
+        }
+
+        It 'should default DangerousEnrollee to an empty array' {
+            $obj = New-MockLS2AdcsObject
+            $obj.DangerousEnrollee | Should -Not -BeNullOrEmpty -Because 'DangerousEnrollee should be initialized as @(), not $null'
+            $obj.DangerousEnrollee.Count | Should -Be 0
+        }
+
+        It 'should default LowPrivilegeEnrollee to an empty array' {
+            $obj = New-MockLS2AdcsObject
+            $obj.LowPrivilegeEnrollee.Count | Should -Be 0
+        }
+
+        It 'should default DangerousEditor to an empty array' {
+            $obj = New-MockLS2AdcsObject
+            $obj.DangerousEditor.Count | Should -Be 0
+        }
+
+        It 'should allow Enabled to be set to $true and read back' {
+            $obj = New-MockLS2AdcsObject -Properties @{ Enabled = $true }
+            $obj.Enabled | Should -BeTrue
+        }
+
+        It 'should allow RPCEncryptionNotRequired to be set and read back' {
+            $obj = New-MockLS2AdcsObject -Properties @{ RPCEncryptionNotRequired = $true }
+            $obj.RPCEncryptionNotRequired | Should -BeTrue
+        }
+
+        It 'should allow SANFlagEnabled to be set and read back' {
+            $obj = New-MockLS2AdcsObject -Properties @{ SANFlagEnabled = $true }
+            $obj.SANFlagEnabled | Should -BeTrue
+        }
+
+        It 'should allow CAFullName to be set and read back' {
+            $obj = New-MockLS2AdcsObject -Properties @{ CAFullName = 'dc01.contoso.com\My-CA' }
+            $obj.CAFullName | Should -Be 'dc01.contoso.com\My-CA'
+        }
+
+        It 'should allow SecurityExtensionDisabled to be set and read back' {
+            $obj = New-MockLS2AdcsObject -Properties @{ SecurityExtensionDisabled = $true }
+            $obj.SecurityExtensionDisabled | Should -BeTrue
+        }
+
+        It 'should allow AuditFilter to be set to an integer and read back' {
+            $obj = New-MockLS2AdcsObject -Properties @{ AuditFilter = 127 }
+            $obj.AuditFilter | Should -Be 127
+        }
+    }
+}

--- a/Tests/Classes/LS2Issue.Tests.ps1
+++ b/Tests/Classes/LS2Issue.Tests.ps1
@@ -1,0 +1,199 @@
+#requires -Version 5.1
+BeforeAll {
+    $ModuleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    Import-Module (Join-Path $ModuleRoot 'Tests' 'Shared' 'TestHelpers.psm1') -Force -ErrorAction Stop
+}
+
+Describe 'LS2Issue class' -Tag 'Unit' {
+
+    Describe 'Constructor' {
+        It 'should construct from a minimal hashtable without throwing' {
+            { New-MockLS2Issue } | Should -Not -Throw
+        }
+
+        It 'should set Technique from the hashtable' {
+            $issue = New-MockLS2Issue -Overrides @{ Technique = 'ESC6' }
+            $issue.Technique | Should -Be 'ESC6'
+        }
+
+        It 'should set Forest from the hashtable' {
+            $issue = New-MockLS2Issue -Overrides @{ Forest = 'fabrikam.com' }
+            $issue.Forest | Should -Be 'fabrikam.com'
+        }
+
+        It 'should set Name from the hashtable' {
+            $issue = New-MockLS2Issue -Overrides @{ Name = 'MyCA' }
+            $issue.Name | Should -Be 'MyCA'
+        }
+
+        It 'should set IdentityReference from the hashtable' {
+            $issue = New-MockLS2Issue -Overrides @{ IdentityReference = 'CONTOSO\Admins' }
+            $issue.IdentityReference | Should -Be 'CONTOSO\Admins'
+        }
+
+        It 'should set CAFullName from the hashtable' {
+            $issue = New-MockLS2Issue -Overrides @{ CAFullName = 'myserver\MyCA' }
+            $issue.CAFullName | Should -Be 'myserver\MyCA'
+        }
+
+        It 'should set Issue, Fix, and Revert strings from the hashtable' {
+            $issue = New-MockLS2Issue -Overrides @{
+                Issue  = 'Vulnerability description.'
+                Fix    = '# Fix script'
+                Revert = '# Revert script'
+            }
+            $issue.Issue  | Should -Be 'Vulnerability description.'
+            $issue.Fix    | Should -Be '# Fix script'
+            $issue.Revert | Should -Be '# Revert script'
+        }
+
+        It 'should leave unprovided optional properties null' {
+            $issue = New-MockLS2Issue
+            $issue.CAFullName           | Should -BeNullOrEmpty
+            $issue.IdentityReference    | Should -BeNullOrEmpty
+            $issue.IdentityReferenceSID | Should -BeNullOrEmpty
+            $issue.Owner                | Should -BeNullOrEmpty
+            $issue.Enabled              | Should -BeNullOrEmpty
+            $issue.MemberCount          | Should -BeNullOrEmpty
+        }
+    }
+
+    Describe 'GetIdentifier()' {
+        It 'should return "Technique: Name - IdentityReference" when IdentityReference is set' {
+            $issue = New-MockLS2Issue -Overrides @{
+                Technique         = 'ESC1'
+                Name              = 'UserTemplate'
+                IdentityReference = 'CONTOSO\Domain Users'
+            }
+            $issue.GetIdentifier() | Should -Be 'ESC1: UserTemplate - CONTOSO\Domain Users'
+        }
+
+        It 'should return "Technique: Name - Owner: <owner>" when only Owner is set' {
+            $issue = New-MockLS2Issue -Overrides @{
+                Technique = 'ESC4o'
+                Name      = 'SomeTemplate'
+                Owner     = 'CONTOSO\attacker'
+            }
+            $issue.GetIdentifier() | Should -Be 'ESC4o: SomeTemplate - Owner: CONTOSO\attacker'
+        }
+
+        It 'should return "Technique: Name" when neither IdentityReference nor Owner is set' {
+            $issue = New-MockLS2Issue -Overrides @{
+                Technique = 'ESC11'
+                Name      = 'MyCA'
+            }
+            $issue.GetIdentifier() | Should -Be 'ESC11: MyCA'
+        }
+
+        It 'should prefer IdentityReference over Owner when both are set' {
+            $issue = New-MockLS2Issue -Overrides @{
+                Technique         = 'ESC1'
+                Name              = 'T'
+                IdentityReference = 'CONTOSO\Users'
+                Owner             = 'CONTOSO\Admin'
+            }
+            $issue.GetIdentifier() | Should -BeLike '*CONTOSO\Users*'
+            $issue.GetIdentifier() | Should -Not -BeLike '*Owner:*'
+        }
+    }
+
+    Describe 'HasPrincipal()' {
+        It 'should return true when IdentityReference is set' {
+            $issue = New-MockLS2Issue -Overrides @{ IdentityReference = 'CONTOSO\Users' }
+            $issue.HasPrincipal() | Should -BeTrue
+        }
+
+        It 'should return false when IdentityReference is null' {
+            $issue = New-MockLS2Issue
+            $issue.HasPrincipal() | Should -BeFalse
+        }
+
+        It 'should return false when IdentityReference is an empty string' -Tag 'EdgeCase' {
+            $issue = New-MockLS2Issue -Overrides @{ IdentityReference = '' }
+            $issue.HasPrincipal() | Should -BeFalse
+        }
+    }
+
+    Describe 'IsTemplateIssue()' {
+        It 'should return true when Enabled is $true' {
+            $issue = New-MockLS2Issue -Overrides @{ Enabled = $true }
+            $issue.IsTemplateIssue() | Should -BeTrue
+        }
+
+        It 'should return true when Enabled is $false (explicitly set, not null)' {
+            $issue = New-MockLS2Issue -Overrides @{ Enabled = $false }
+            $issue.IsTemplateIssue() | Should -BeTrue
+        }
+
+        It 'should return false when Enabled is null' {
+            $issue = New-MockLS2Issue
+            $issue.IsTemplateIssue() | Should -BeFalse
+        }
+    }
+
+    Describe 'IsCAIssue()' {
+        It 'should return true when CAFullName is set' {
+            $issue = New-MockLS2Issue -Overrides @{ CAFullName = 'myserver\MyCA' }
+            $issue.IsCAIssue() | Should -BeTrue
+        }
+
+        It 'should return false when CAFullName is null' {
+            $issue = New-MockLS2Issue
+            $issue.IsCAIssue() | Should -BeFalse
+        }
+
+        It 'should return false when CAFullName is an empty string' -Tag 'EdgeCase' {
+            $issue = New-MockLS2Issue -Overrides @{ CAFullName = '' }
+            $issue.IsCAIssue() | Should -BeFalse
+        }
+    }
+
+    Describe 'Matches()' {
+        BeforeAll {
+            $script:BaseProps = @{
+                Technique             = 'ESC1'
+                DistinguishedName     = 'CN=T,CN=Certificate Templates,DC=contoso,DC=com'
+                IdentityReferenceSID  = 'S-1-5-21-1234-5678-9012-1001'
+                ActiveDirectoryRights = 'ExtendedRight'
+                CAFullName            = $null
+                Owner                 = $null
+            }
+        }
+
+        It 'should return true for two issues with identical core properties' {
+            $issueA = New-MockLS2Issue -Overrides $script:BaseProps
+            $issueB = New-MockLS2Issue -Overrides $script:BaseProps
+            $issueA.Matches($issueB) | Should -BeTrue
+        }
+
+        It 'should return false when Technique differs' {
+            $issueA = New-MockLS2Issue -Overrides $script:BaseProps
+            $issueB = New-MockLS2Issue -Overrides ($script:BaseProps + @{ Technique = 'ESC2' })
+            $issueA.Matches($issueB) | Should -BeFalse
+        }
+
+        It 'should return false when DistinguishedName differs' {
+            $issueA = New-MockLS2Issue -Overrides $script:BaseProps
+            $issueB = New-MockLS2Issue -Overrides ($script:BaseProps + @{ DistinguishedName = 'CN=Other,DC=contoso,DC=com' })
+            $issueA.Matches($issueB) | Should -BeFalse
+        }
+
+        It 'should return false when IdentityReferenceSID differs' {
+            $issueA = New-MockLS2Issue -Overrides $script:BaseProps
+            $issueB = New-MockLS2Issue -Overrides ($script:BaseProps + @{ IdentityReferenceSID = 'S-1-5-21-9999-9999-9999-500' })
+            $issueA.Matches($issueB) | Should -BeFalse
+        }
+
+        It 'should return false when ActiveDirectoryRights differs' {
+            $issueA = New-MockLS2Issue -Overrides $script:BaseProps
+            $issueB = New-MockLS2Issue -Overrides ($script:BaseProps + @{ ActiveDirectoryRights = 'GenericAll' })
+            $issueA.Matches($issueB) | Should -BeFalse
+        }
+
+        It 'should return false when argument is null' -Tag 'EdgeCase' {
+            $issue = New-MockLS2Issue -Overrides $script:BaseProps
+            $issue.Matches($null) | Should -BeFalse
+        }
+    }
+}

--- a/Tests/Locksmith2.Tests.ps1
+++ b/Tests/Locksmith2.Tests.ps1
@@ -1,0 +1,65 @@
+#requires -Version 5.1
+BeforeAll {
+    $ModuleRoot   = Split-Path -Parent $PSScriptRoot
+    $ManifestPath = Join-Path $ModuleRoot 'Locksmith2.psd1'
+    Import-Module $ManifestPath -Force -ErrorAction Stop
+}
+
+Describe 'Locksmith2 Module Manifest' -Tag 'Unit' {
+    BeforeAll {
+        $ManifestPath = Join-Path (Split-Path -Parent $PSScriptRoot) 'Locksmith2.psd1'
+    }
+
+    It 'should have a valid module manifest' {
+        { Test-ModuleManifest -Path $ManifestPath -ErrorAction Stop } | Should -Not -Throw
+    }
+
+    It 'should import without errors' {
+        { Import-Module $ManifestPath -Force -ErrorAction Stop } | Should -Not -Throw
+    }
+
+    It 'should target PowerShell 5.1 or higher' {
+        $manifest = Test-ModuleManifest -Path $ManifestPath -ErrorAction SilentlyContinue
+        [version]$manifest.PowerShellVersion | Should -BeLessOrEqual ([version]'5.1')
+    }
+
+    It 'should declare both Desktop and Core compatible editions' {
+        $manifest = Test-ModuleManifest -Path $ManifestPath -ErrorAction SilentlyContinue
+        $manifest.CompatiblePSEditions | Should -Contain 'Desktop'
+        $manifest.CompatiblePSEditions | Should -Contain 'Core'
+    }
+}
+
+Describe 'Locksmith2 Public API' -Tag 'Unit' {
+    $ExpectedFunctions = @(
+        'Find-LS2VulnerableTemplate'
+        'Find-LS2VulnerableCA'
+        'Find-LS2VulnerableObject'
+        'Find-LS2RiskyPrincipal'
+        'Get-LS2Stores'
+        'Invoke-Locksmith2'
+        'New-LS2Dashboard'
+        'Set-LS2Credential'
+        'Set-LS2Forest'
+    )
+
+    It 'should export <_>' -ForEach $ExpectedFunctions {
+        Get-Command -Module Locksmith2 -Name $_ -ErrorAction SilentlyContinue |
+            Should -Not -BeNullOrEmpty -Because "the public cmdlet '$_' must be accessible"
+    }
+}
+
+Describe 'Locksmith2 PSScriptAnalyzer' -Tag 'Unit', 'ScriptAnalyzer' {
+    BeforeAll {
+        $ModuleRoot   = Split-Path -Parent $PSScriptRoot
+        $PSAAvailable = $null -ne (Get-Module PSScriptAnalyzer -ListAvailable -ErrorAction SilentlyContinue)
+    }
+
+    It 'should have no PSScriptAnalyzer errors or warnings' -Skip:(-not $PSAAvailable) {
+        $violations = Invoke-ScriptAnalyzer -Path $ModuleRoot -Recurse -Severity Warning, Error -ErrorAction SilentlyContinue
+        # Exclude the Tests directory from analysis
+        $violations = $violations | Where-Object { $_.ScriptPath -notlike '*Tests*' }
+        $violations | Format-List ScriptPath, RuleName, Message | Out-String | Write-Verbose -Verbose
+        $violations | Should -BeNullOrEmpty
+    }
+}

--- a/Tests/Private/Data/ESCDefinitions.Tests.ps1
+++ b/Tests/Private/Data/ESCDefinitions.Tests.ps1
@@ -1,0 +1,107 @@
+#requires -Version 5.1
+BeforeAll {
+    $DataPath = Join-Path $PSScriptRoot '..' '..' '..' 'Private' 'Data' 'ESCDefinitions.psd1'
+    $script:Definitions = Import-PowerShellDataFile -Path $DataPath
+}
+
+Describe 'ESCDefinitions.psd1' -Tag 'Unit' {
+    BeforeAll {
+        # Report all failures in this describe block rather than stopping at the first
+        $PesterPreference = [PesterConfiguration]::Default
+        $PesterPreference.Should.ErrorAction = 'Continue'
+    }
+
+    It 'should import without error' {
+        $script:Definitions | Should -Not -BeNullOrEmpty
+    }
+
+    It 'should be a hashtable' {
+        $script:Definitions | Should -BeOfType [hashtable]
+    }
+
+    Context 'Required techniques are present' {
+        $RequiredTechniques = @(
+            'ESC1', 'ESC2', 'ESC3c1', 'ESC3c2',
+            'ESC4a', 'ESC4o',
+            'ESC5a', 'ESC5o',
+            'ESC6', 'ESC7a', 'ESC7m',
+            'ESC9', 'ESC11', 'ESC16'
+        )
+
+        It 'should contain technique <_>' -ForEach $RequiredTechniques {
+            $script:Definitions.Keys | Should -Contain $_
+        }
+    }
+
+    Context 'Each technique has required keys' {
+        $RequiredTechniques = @(
+            'ESC1', 'ESC2', 'ESC3c1', 'ESC3c2',
+            'ESC4a', 'ESC4o',
+            'ESC5a', 'ESC5o',
+            'ESC6', 'ESC7a', 'ESC7m',
+            'ESC9', 'ESC11', 'ESC16'
+        )
+
+        It '<_> should have a Technique key' -ForEach $RequiredTechniques {
+            $script:Definitions[$_].Keys | Should -Contain 'Technique'
+        }
+
+        It '<_> should have an IssueTemplate key' -ForEach $RequiredTechniques {
+            $script:Definitions[$_].Keys | Should -Contain 'IssueTemplate'
+        }
+
+        It '<_> should have a FixTemplate key' -ForEach $RequiredTechniques {
+            $script:Definitions[$_].Keys | Should -Contain 'FixTemplate'
+        }
+
+        It '<_> should have a RevertTemplate key' -ForEach $RequiredTechniques {
+            $script:Definitions[$_].Keys | Should -Contain 'RevertTemplate'
+        }
+
+        It '<_> Technique property should match its key' -ForEach $RequiredTechniques {
+            $script:Definitions[$_].Technique | Should -Be $_
+        }
+    }
+
+    Context 'Techniques with Conditions have valid structure' {
+        $TechniquesWithConditions = @('ESC1', 'ESC2', 'ESC3c1', 'ESC3c2', 'ESC9')
+
+        It '<_> should have a non-empty Conditions array' -ForEach $TechniquesWithConditions {
+            $script:Definitions[$_].Conditions | Should -Not -BeNullOrEmpty
+        }
+
+        It 'every Condition in <_> should have a Property key' -ForEach $TechniquesWithConditions {
+            foreach ($condition in $script:Definitions[$_].Conditions) {
+                $condition.Keys | Should -Contain 'Property' -Because "condition '$($condition | Out-String)' is missing Property"
+            }
+        }
+
+        It 'every Condition in <_> should have a Value key' -ForEach $TechniquesWithConditions {
+            foreach ($condition in $script:Definitions[$_].Conditions) {
+                $condition.Keys | Should -Contain 'Value' -Because "condition '$($condition | Out-String)' is missing Value"
+            }
+        }
+    }
+
+    Context 'IssueTemplate, FixTemplate, RevertTemplate are non-empty' {
+        $AllTechniques = @(
+            'ESC1', 'ESC2', 'ESC3c1', 'ESC3c2',
+            'ESC4a', 'ESC4o',
+            'ESC5a', 'ESC5o',
+            'ESC6', 'ESC7a', 'ESC7m',
+            'ESC9', 'ESC11', 'ESC16'
+        )
+
+        It '<_> IssueTemplate should not be null or empty' -ForEach $AllTechniques {
+            $script:Definitions[$_].IssueTemplate | Should -Not -BeNullOrEmpty
+        }
+
+        It '<_> FixTemplate should not be null or empty' -ForEach $AllTechniques {
+            $script:Definitions[$_].FixTemplate | Should -Not -BeNullOrEmpty
+        }
+
+        It '<_> RevertTemplate should not be null or empty' -ForEach $AllTechniques {
+            $script:Definitions[$_].RevertTemplate | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/Tests/Private/Utility/Expand-IssueTemplate.Tests.ps1
+++ b/Tests/Private/Utility/Expand-IssueTemplate.Tests.ps1
@@ -1,0 +1,134 @@
+#requires -Version 5.1
+BeforeAll {
+    # Dot-source via scriptblock to handle UTF-16LE source encoding
+    $SourcePath = Join-Path $PSScriptRoot '..' '..' '..' 'Private' 'Utility' 'Expand-IssueTemplate.ps1'
+    . ([scriptblock]::Create((Get-Content -Path $SourcePath -Raw)))
+}
+
+Describe 'Expand-IssueTemplate' -Tag 'Unit' {
+    BeforeAll {
+        $script:BaseConfig = @{
+            IssueTemplate  = @('$(IdentityReference) can enroll in $(TemplateName).')
+            FixTemplate    = @('# Fix', 'Set-ADObject $(DistinguishedName)')
+            RevertTemplate = @('# Revert', 'Set-ADObject $(DistinguishedName)')
+        }
+        $script:BaseVars = @{
+            IdentityReference = 'CONTOSO\Domain Users'
+            TemplateName      = 'WebServer'
+            DistinguishedName = 'CN=WebServer,CN=Certificate Templates,DC=contoso,DC=com'
+        }
+    }
+
+    Describe 'Return value structure' {
+        It 'should return a hashtable' {
+            $result = Expand-IssueTemplate -Config $script:BaseConfig -Variables $script:BaseVars
+            $result | Should -BeOfType [hashtable]
+        }
+
+        It 'should return Issue, Fix, and Revert keys' {
+            $result = Expand-IssueTemplate -Config $script:BaseConfig -Variables $script:BaseVars
+            $result.Keys | Should -Contain 'Issue'
+            $result.Keys | Should -Contain 'Fix'
+            $result.Keys | Should -Contain 'Revert'
+        }
+    }
+
+    Describe 'Variable substitution' {
+        It 'should substitute IdentityReference in the Issue string' {
+            $result = Expand-IssueTemplate -Config $script:BaseConfig -Variables $script:BaseVars
+            $result.Issue | Should -BeLike '*CONTOSO\Domain Users*'
+        }
+
+        It 'should substitute TemplateName in the Issue string' {
+            $result = Expand-IssueTemplate -Config $script:BaseConfig -Variables $script:BaseVars
+            $result.Issue | Should -BeLike '*WebServer*'
+        }
+
+        It 'should substitute DistinguishedName in the Fix string' {
+            $result = Expand-IssueTemplate -Config $script:BaseConfig -Variables $script:BaseVars
+            $result.Fix | Should -BeLike '*CN=WebServer*'
+        }
+
+        It 'should substitute DistinguishedName in the Revert string' {
+            $result = Expand-IssueTemplate -Config $script:BaseConfig -Variables $script:BaseVars
+            $result.Revert | Should -BeLike '*CN=WebServer*'
+        }
+
+        It 'should perform multiple variable substitutions in one string' {
+            $config = @{
+                IssueTemplate  = @('$(IdentityReference) abused $(TemplateName) on $(DistinguishedName).')
+                FixTemplate    = @('# no-op')
+                RevertTemplate = @('# no-op')
+            }
+            $result = Expand-IssueTemplate -Config $config -Variables $script:BaseVars
+            $result.Issue | Should -Be 'CONTOSO\Domain Users abused WebServer on CN=WebServer,CN=Certificate Templates,DC=contoso,DC=com.'
+        }
+
+        It 'should replace null variable values with empty string' -Tag 'EdgeCase' {
+            $config = @{
+                IssueTemplate  = @('Hello $(Name).')
+                FixTemplate    = @('# no-op')
+                RevertTemplate = @('# no-op')
+            }
+            $result = Expand-IssueTemplate -Config $config -Variables @{ Name = $null }
+            $result.Issue | Should -Be 'Hello .'
+        }
+
+        It 'should leave unexpanded placeholders intact when variable is not provided' -Tag 'EdgeCase' {
+            $config = @{
+                IssueTemplate  = @('Value: $(Missing).')
+                FixTemplate    = @('# no-op')
+                RevertTemplate = @('# no-op')
+            }
+            $result = Expand-IssueTemplate -Config $config -Variables @{}
+            $result.Issue | Should -Be 'Value: $(Missing).'
+        }
+    }
+
+    Describe 'Array template joining' {
+        It 'should join Issue template array elements with no separator' {
+            $config = @{
+                IssueTemplate  = @('Part one. ', 'Part two. ', 'Part three.')
+                FixTemplate    = @('# no-op')
+                RevertTemplate = @('# no-op')
+            }
+            $result = Expand-IssueTemplate -Config $config -Variables @{}
+            $result.Issue | Should -Be 'Part one. Part two. Part three.'
+        }
+
+        It 'should join Fix template array elements with newlines' {
+            $result = Expand-IssueTemplate -Config $script:BaseConfig -Variables $script:BaseVars
+            $result.Fix | Should -Be "# Fix`nSet-ADObject CN=WebServer,CN=Certificate Templates,DC=contoso,DC=com"
+        }
+
+        It 'should join Revert template array elements with newlines' {
+            $result = Expand-IssueTemplate -Config $script:BaseConfig -Variables $script:BaseVars
+            $result.Revert | Should -Be "# Revert`nSet-ADObject CN=WebServer,CN=Certificate Templates,DC=contoso,DC=com"
+        }
+
+        It 'should handle a single-string IssueTemplate (not an array)' {
+            $config = @{
+                IssueTemplate  = 'Single string template.'
+                FixTemplate    = @('# no-op')
+                RevertTemplate = @('# no-op')
+            }
+            $result = Expand-IssueTemplate -Config $config -Variables @{}
+            $result.Issue | Should -Be 'Single string template.'
+        }
+    }
+
+    Describe 'IssueTemplate override parameter' {
+        It 'should use the override instead of Config.IssueTemplate when provided' {
+            $result = Expand-IssueTemplate -Config $script:BaseConfig -Variables $script:BaseVars `
+                -IssueTemplate @('Override: $(TemplateName)')
+            $result.Issue | Should -Be 'Override: WebServer'
+        }
+
+        It 'should still use Config.FixTemplate and Config.RevertTemplate when override is used' {
+            $result = Expand-IssueTemplate -Config $script:BaseConfig -Variables $script:BaseVars `
+                -IssueTemplate @('Override.')
+            $result.Fix    | Should -Not -BeNullOrEmpty
+            $result.Revert | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/Tests/Private/Utility/Get-ForestNameFromDN.Tests.ps1
+++ b/Tests/Private/Utility/Get-ForestNameFromDN.Tests.ps1
@@ -1,0 +1,44 @@
+#requires -Version 5.1
+BeforeAll {
+    # Dot-source via scriptblock to handle UTF-16LE source encoding
+    $SourcePath = Join-Path $PSScriptRoot '..' '..' '..' 'Private' 'Utility' 'Get-ForestNameFromDN.ps1'
+    . ([scriptblock]::Create((Get-Content -Path $SourcePath -Raw)))
+}
+
+Describe 'Get-ForestNameFromDN' -Tag 'Unit' {
+    It 'should return contoso.com for a single-level domain DN' {
+        Get-ForestNameFromDN -DistinguishedName 'CN=Template,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com' |
+            Should -Be 'contoso.com'
+    }
+
+    It 'should return child.contoso.com for a multi-level domain DN' {
+        Get-ForestNameFromDN -DistinguishedName 'CN=User,CN=Users,DC=child,DC=contoso,DC=com' |
+            Should -Be 'child.contoso.com'
+    }
+
+    It 'should return a.b.c.d for a four-part domain DN' {
+        Get-ForestNameFromDN -DistinguishedName 'CN=Obj,DC=a,DC=b,DC=c,DC=d' |
+            Should -Be 'a.b.c.d'
+    }
+
+    It 'should return fabrikam.org via pipeline input' {
+        'CN=User,CN=Users,DC=fabrikam,DC=org' | Get-ForestNameFromDN |
+            Should -Be 'fabrikam.org'
+    }
+
+    It 'should return Unknown when DN has no DC components' {
+        Get-ForestNameFromDN -DistinguishedName 'CN=SomeObject,CN=SomeContainer' |
+            Should -Be 'Unknown'
+    }
+
+    It 'should return Unknown for an empty string' -Tag 'EdgeCase' {
+        Get-ForestNameFromDN -DistinguishedName '' |
+            Should -Be 'Unknown'
+    }
+
+    It 'should process multiple pipeline values independently' {
+        $results = @('CN=A,DC=alpha,DC=com', 'CN=B,DC=beta,DC=net') | Get-ForestNameFromDN
+        $results[0] | Should -Be 'alpha.com'
+        $results[1] | Should -Be 'beta.net'
+    }
+}

--- a/Tests/Shared/TestHelpers.psm1
+++ b/Tests/Shared/TestHelpers.psm1
@@ -1,0 +1,214 @@
+#requires -Version 5.1
+<#
+.SYNOPSIS
+    Shared test helpers for Locksmith2 Pester tests.
+
+.DESCRIPTION
+    Provides mock factory functions for LS2AdcsObject, LS2Issue, and LS2Principal,
+    and a PSScriptAnalyzer helper. Import this module in BeforeAll blocks:
+
+        Import-Module (Join-Path $PSScriptRoot '..' 'Shared' 'TestHelpers.psm1') -Force
+
+.NOTES
+    LS2AdcsObject and LS2Principal have AD-dependent constructors. Tests bypass them
+    using GetUninitializedObject, which creates an instance without invoking any
+    constructor. Properties are then set directly.
+
+    Store resets ($script:IssueStore, etc.) are NOT abstracted here because helper
+    functions cannot set $script: variables in Locksmith2's module scope.
+    Inline the reset in each InModuleScope BeforeEach block.
+#>
+
+function New-MockLS2AdcsObject {
+    <#
+    .SYNOPSIS
+        Creates an LS2AdcsObject without invoking the DirectoryEntry constructor.
+
+    .PARAMETER Properties
+        Hashtable of property overrides applied after defaults are set.
+
+    .EXAMPLE
+        $template = New-MockLS2AdcsObject
+        $ca = New-MockLS2AdcsObject -Properties @{
+            SchemaClassName = 'pKIEnrollmentService'
+            objectClass     = @('top', 'pKIEnrollmentService')
+            SANFlagEnabled  = $true
+        }
+    #>
+    [CmdletBinding()]
+    [OutputType([LS2AdcsObject])]
+    param(
+        [Parameter()]
+        [hashtable]$Properties = @{}
+    )
+
+    $obj = [System.Runtime.Serialization.FormatterServices]::GetUninitializedObject([LS2AdcsObject])
+
+    # Defaults: a typical certificate template
+    $obj.objectClass              = @('top', 'pKICertificateTemplate')
+    $obj.SchemaClassName          = 'pKICertificateTemplate'
+    $obj.distinguishedName        = 'CN=TestTemplate,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
+    $obj.name                     = 'TestTemplate'
+    $obj.displayName              = $null
+    $obj.cn                       = 'TestTemplate'
+    $obj.Path                     = $null
+    $obj.Owner                    = $null
+    $obj.HasNonStandardOwner      = $null
+    $obj.flags                    = $null
+    $obj.pKIDefaultKeySpec        = $null
+    $obj.pKIMaxIssuingDepth       = $null
+    $obj.pKICriticalExtensions    = @()
+    $obj.pKIExtendedKeyUsage      = @()
+    $obj.CertificateNameFlag      = $null
+    $obj.EnrollmentFlag           = $null
+    $obj.PrivateKeyFlag           = $null
+    $obj.RASignature              = $null
+    $obj.RAApplicationPolicies    = @()
+    $obj.TemplateSchemaVersion    = $null
+    $obj.TemplateMinorRevision    = $null
+    $obj.certificateTemplates     = @()
+    $obj.dNSHostName              = $null
+    $obj.CAFullName               = $null
+    $obj.CAAdministrators         = @()
+    $obj.CertificateManagers      = @()
+    $obj.DangerousCAAdministrator          = @()
+    $obj.DangerousCAAdministratorNames     = @()
+    $obj.LowPrivilegeCAAdministrator       = @()
+    $obj.LowPrivilegeCAAdministratorNames  = @()
+    $obj.DangerousCACertificateManager         = @()
+    $obj.DangerousCACertificateManagerNames    = @()
+    $obj.LowPrivilegeCACertificateManager      = @()
+    $obj.LowPrivilegeCACertificateManagerNames = @()
+    $obj.SANAllowed               = $null
+    $obj.AuthenticationEKUExist   = $null
+    $obj.AnyPurposeEKUExist       = $null
+    $obj.EnrollmentAgentEKUExist  = $null
+    $obj.NoSecurityExtension      = $null
+    $obj.RequiresEnrollmentAgentSignature = $null
+    $obj.DangerousEnrollee        = @()
+    $obj.DangerousEnrolleeNames   = @()
+    $obj.LowPrivilegeEnrollee     = @()
+    $obj.LowPrivilegeEnrolleeNames = @()
+    $obj.DangerousEditor          = @()
+    $obj.DangerousEditorNames     = @()
+    $obj.LowPrivilegeEditor       = @()
+    $obj.LowPrivilegeEditorNames  = @()
+    $obj.ManagerApprovalNotRequired     = $null
+    $obj.AuthorizedSignatureNotRequired = $null
+    $obj.Enabled                  = $null
+    $obj.EnabledOn                = @()
+    $obj.ComputerPrincipal        = $null
+    $obj.RPCEncryptionNotRequired = $null
+    $obj.EditFlags                = @()
+    $obj.SANFlagEnabled           = $null
+    $obj.InterfaceFlags           = @()
+    $obj.AuditFilter              = $null
+    $obj.DisableExtensionList     = @()
+    $obj.SecurityExtensionDisabled = $null
+
+    foreach ($key in $Properties.Keys) {
+        $obj.$key = $Properties[$key]
+    }
+
+    return $obj
+}
+
+function New-MockLS2Issue {
+    <#
+    .SYNOPSIS
+        Creates an LS2Issue using the hashtable constructor, with sensible defaults.
+
+    .PARAMETER Overrides
+        Hashtable of property overrides applied on top of defaults.
+
+    .EXAMPLE
+        $issue = New-MockLS2Issue
+        $caIssue = New-MockLS2Issue -Overrides @{ Technique = 'ESC6'; CAFullName = 'myserver\MyCA' }
+    #>
+    [CmdletBinding()]
+    [OutputType([LS2Issue])]
+    param(
+        [Parameter()]
+        [hashtable]$Overrides = @{}
+    )
+
+    $defaults = @{
+        Technique         = 'ESC1'
+        Forest            = 'contoso.com'
+        Name              = 'TestTemplate'
+        DistinguishedName = 'CN=TestTemplate,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
+        ObjectClass       = 'pKICertificateTemplate'
+        Issue             = 'Test issue description.'
+        Fix               = '# Fix script'
+        Revert            = '# Revert script'
+    }
+
+    foreach ($key in $Overrides.Keys) {
+        $defaults[$key] = $Overrides[$key]
+    }
+
+    return [LS2Issue]::new($defaults)
+}
+
+function New-MockLS2Principal {
+    <#
+    .SYNOPSIS
+        Creates an LS2Principal without invoking the SearchResult constructor.
+
+    .PARAMETER Properties
+        Hashtable of property overrides applied after defaults are set.
+
+    .EXAMPLE
+        $principal = New-MockLS2Principal
+        $group = New-MockLS2Principal -Properties @{ objectClass = 'group'; MemberCount = 5 }
+    #>
+    [CmdletBinding()]
+    [OutputType([LS2Principal])]
+    param(
+        [Parameter()]
+        [hashtable]$Properties = @{}
+    )
+
+    $obj = [System.Runtime.Serialization.FormatterServices]::GetUninitializedObject([LS2Principal])
+
+    $obj.distinguishedName  = 'CN=TestUser,CN=Users,DC=contoso,DC=com'
+    $obj.objectSid          = 'S-1-5-21-1234567890-1234567890-1234567890-1001'
+    $obj.sAMAccountName     = 'TestUser'
+    $obj.objectClass        = 'user'
+    $obj.displayName        = $null
+    $obj.NTAccountName      = 'CONTOSO\TestUser'
+    $obj.userPrincipalName  = $null
+    $obj.memberOf           = @()
+    $obj.MemberCount        = 0
+
+    foreach ($key in $Properties.Keys) {
+        $obj.$key = $Properties[$key]
+    }
+
+    return $obj
+}
+
+function Invoke-PSScriptAnalyzerCheck {
+    <#
+    .SYNOPSIS
+        Runs PSScriptAnalyzer on a path. Returns empty array if PSSA is not installed.
+
+    .PARAMETER Path
+        Path to analyze. Passed to Invoke-ScriptAnalyzer -Path.
+    #>
+    [CmdletBinding()]
+    [OutputType([object[]])]
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    if (-not (Get-Module -Name PSScriptAnalyzer -ListAvailable -ErrorAction SilentlyContinue)) {
+        Write-Warning 'PSScriptAnalyzer is not installed — skipping static analysis checks.'
+        return @()
+    }
+
+    return Invoke-ScriptAnalyzer -Path $Path -Recurse -Severity Warning, Error -ErrorAction SilentlyContinue
+}
+
+Export-ModuleMember -Function 'New-MockLS2AdcsObject', 'New-MockLS2Issue', 'New-MockLS2Principal', 'Invoke-PSScriptAnalyzerCheck'


### PR DESCRIPTION
## Summary

Establishes the foundational Pester v5 test infrastructure and fixes two build reliability issues. No production logic was modified.

---

## Changes

### Tests (new)
- `Locksmith2.Pester.config.ps1` — Pester v5 run configuration with code coverage and test result output
- `Tests/Shared/TestHelpers.psm1` — shared mock factories: `New-MockLS2AdcsObject`, `New-MockLS2Issue`, `New-MockLS2Principal`, `Invoke-PSScriptAnalyzerCheck`; uses `GetUninitializedObject` to bypass AD-dependent constructors
- `Tests/Locksmith2.Tests.ps1` — module manifest validation, public API surface smoke tests, optional PSScriptAnalyzer pass
- `Tests/Classes/LS2Issue.Tests.ps1` — constructor, `GetIdentifier()`, `HasPrincipal()`, `IsTemplateIssue()`, `IsCAIssue()`, `Matches()` (~20 tests)
- `Tests/Classes/LS2AdcsObject.Tests.ps1` — `IsCertificateTemplate()`, `IsCertificationAuthority()`, `GetFriendlyName()`, computed property read/write (~20 tests)
- `Tests/Private/Data/ESCDefinitions.Tests.ps1` — validates all 14 technique definitions (required keys, Conditions structure, non-empty templates)
- `Tests/Private/Utility/Get-ForestNameFromDN.Tests.ps1` — pure-logic DN parsing, pipeline input, edge cases (7 tests)
- `Tests/Private/Utility/Expand-IssueTemplate.Tests.ps1` — variable substitution, array joining, override parameter (12 tests)

### Build fixes
- `Build/Build-Module.ps1` — added PSScriptAnalyzer assembly guard: detects VS Code host or pre-loaded assembly and re-invokes in a clean `pwsh -NoProfile` child process; removed `DefaultPSD1` from format targets (PSPublishModule was rewriting the source PSD1 with mixed CRLF/LF endings on each run, causing the formatter to throw)
- `Locksmith2.psd1` — normalized mixed CRLF/LF line endings to LF

---

## Testing

All new tests are tagged `Unit` and require no AD connectivity. Run with:

```powershell
Invoke-Pester -Configuration (. .\Locksmith2.Pester.config.ps1)