### PR TITLE
refactor(data): convert Private/Data .psd1 files to .ps1 for PSPublishModule compatibility

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -136,7 +136,6 @@ Build-Module -ModuleName 'Locksmith2' {
 
     # configuration for documentation, at the same time it enables documentation processing
     New-ConfigurationDocumentation -Enable:$false -StartClean -UpdateWhenNew -PathReadme 'Docs\Readme.md' -Path 'Docs'
-    New-ConfigurationInformation -IncludeAll 'Private\Data'
     New-ConfigurationImportModule -ImportSelf -ImportRequiredModules
 
     New-ConfigurationBuild -Enable:$true -SignModule:$false -DeleteTargetModuleBeforeBuild -MergeModuleOnBuild -MergeFunctionsFromApprovedModules -DoNotAttemptToFixRelativePaths -UseWildcardForFunctions

--- a/Private/Data/AceDefinitions.ps1
+++ b/Private/Data/AceDefinitions.ps1
@@ -1,0 +1,277 @@
+<#
+.SYNOPSIS
+Dangerous ACE Definitions for AD CS Security Auditing
+
+.DESCRIPTION
+This PowerShell Data File defines Active Directory permissions that are considered
+dangerous when granted on AD CS objects (templates, CAs, containers, computer accounts).
+These permissions enable various privilege escalation attacks by allowing principals to 
+modify object settings to make them exploitable.
+
+Key attack vectors by object class:
+- Templates (pKICertificateTemplate): ESC1, ESC4 - Modify SAN/EKU/approval settings
+- CAs (pKIEnrollmentService): ESC7 - Grant ManageCA/ManageCertificates rights
+- Containers (container, certificationAuthority): ESC5 - Create vulnerable templates/CAs, modify NTAuthCertificates
+- Computers (computer): ESC9, ESC10 - Modify CA host computer account settings
+
+Each entry includes:
+- Name: Descriptive name for the permission
+- Rights: ActiveDirectoryRights value to match
+- ObjectTypeGUID: GUID for property-specific permissions ($null for generic rights)
+- ObjectTypeName: Human-readable property name (e.g., 'msPKI-Certificate-Name-Flag')
+- ApplicableToClasses: Array of objectClass/SchemaClassName values where this is dangerous
+- Description: What the permission allows and why it's dangerous
+
+.NOTES
+ObjectTypeGUID values for AD CS properties:
+
+Template properties (pKICertificateTemplate):
+- msPKI-Certificate-Name-Flag: ea1dddc4-60ff-416e-8cc0-17cee534bce7
+- pKIExtendedKeyUsage: e0fa1e69-9b45-11d0-afdd-00c04fd930c9
+- msPKI-Enrollment-Flag: 1ede2375-5dd4-4fca-b62f-75ff65cc1c21
+- msPKI-RA-Signature: fc0a1e69-9b45-11d0-afdd-00c04fd930c9
+- pKIMaxIssuingDepth: 281416d9-1968-4c91-b96d-6c6d8b7f3e8c
+- msPKI-Template-Schema-Version: 0b9e865e-3b3b-11d2-90cc-00c04fd91ab1
+- msPKI-Template-Minor-Revision: 0b9e865f-3b3b-11d2-90cc-00c04fd91ab1
+- msPKI-Certificate-Application-Policy: c4e311fc-4e4d-11d1-ab54-00a0c91e9b45
+
+CA properties (pKIEnrollmentService):
+- certificateTemplates: d15b6a0e-94e5-4a82-8c1a-2765f5cf222f
+
+Computer properties (computer):
+- msDS-AllowedToActOnBehalfOfOtherIdentity: 3f78c3e5-f79a-46bd-a0b8-9d18116ddc79
+- servicePrincipalName: f3a64788-5306-11d1-a9c5-0000f80367c1
+- userAccountControl: bf967a68-0de6-11d0-a285-00aa003049e2
+
+Container properties (container, certificationAuthority):
+- cACertificate: bf967932-0de6-11d0-a285-00aa003049e2
+
+Universal:
+- All properties: 00000000-0000-0000-0000-000000000000
+
+.LINK
+https://specterops.io/blog/2021/06/17/certified-pre-owned/
+
+.LINK
+ESC4: Vulnerable Certificate Template Access Control
+
+.LINK
+ESC5: Vulnerable PKI Object Access Control
+
+.LINK
+ESC7: Vulnerable Certificate Authority Access Control
+
+.LINK
+ESC9: No Security Extension (StrongCertificateBindingEnforcement = 0)
+
+.LINK
+ESC10: Weak Certificate Mapping (CertificateMappingMethods allows UPN)
+#>
+
+$script:DangerousAces = data {
+    @(
+        # ============================================================================
+        # Full Control / Ownership (Applies to ALL object classes)
+        # ============================================================================
+
+        @{
+            Name                = 'GenericAll'
+            Rights              = 'GenericAll'
+            ObjectTypeGUID      = $null
+            ObjectTypeName      = $null
+            ApplicableToClasses = @('pKICertificateTemplate', 'pKIEnrollmentService', 'certificationAuthority', 'container', 'computer')
+            Description         = 'Full control over the object - can modify any setting, permissions, or ownership'
+        }
+
+        @{
+            Name                = 'WriteDacl'
+            Rights              = 'WriteDacl'
+            ObjectTypeGUID      = $null
+            ObjectTypeName      = $null
+            ApplicableToClasses = @('pKICertificateTemplate', 'pKIEnrollmentService', 'certificationAuthority', 'container', 'computer')
+            Description         = 'Can modify the discretionary access control list (DACL) - grants ability to give self additional permissions'
+        }
+
+        @{
+            Name                = 'WriteOwner'
+            Rights              = 'WriteOwner'
+            ObjectTypeGUID      = $null
+            ObjectTypeName      = $null
+            ApplicableToClasses = @('pKICertificateTemplate', 'pKIEnrollmentService', 'certificationAuthority', 'container', 'computer')
+            Description         = 'Can take ownership of the object - enables full control via ownership'
+        }
+
+        # ============================================================================
+        # Broad Write Permissions (Applies to ALL object classes)
+        # ============================================================================
+
+        @{
+            Name                = 'GenericWrite'
+            Rights              = 'GenericWrite'
+            ObjectTypeGUID      = $null
+            ObjectTypeName      = $null
+            ApplicableToClasses = @('pKICertificateTemplate', 'pKIEnrollmentService', 'certificationAuthority', 'container', 'computer')
+            Description         = 'Can write to most object properties - enables modification of dangerous configuration settings'
+        }
+
+        @{
+            Name                = 'WriteProperty-AllProperties'
+            Rights              = 'WriteProperty'
+            ObjectTypeGUID      = '00000000-0000-0000-0000-000000000000'
+            ObjectTypeName      = 'All Properties'
+            ApplicableToClasses = @('pKICertificateTemplate', 'pKIEnrollmentService', 'certificationAuthority', 'container', 'computer')
+            Description         = 'Can write to all properties on the object'
+        }
+
+        # ============================================================================
+        # Template-Specific Properties (ESC4a)
+        # ============================================================================
+
+        @{
+            Name                = 'WriteProperty-CertificateNameFlag'
+            Rights              = 'WriteProperty'
+            ObjectTypeGUID      = 'ea1dddc4-60ff-416e-8cc0-17cee534bce7'
+            ObjectTypeName      = 'msPKI-Certificate-Name-Flag'
+            ApplicableToClasses = @('pKICertificateTemplate')
+            Description         = 'Can modify msPKI-Certificate-Name-Flag - enables SAN specification (ESC1 enabler)'
+        }
+
+        @{
+            Name                = 'WriteProperty-ExtendedKeyUsage'
+            Rights              = 'WriteProperty'
+            ObjectTypeGUID      = 'e0fa1e69-9b45-11d0-afdd-00c04fd930c9'
+            ObjectTypeName      = 'pKIExtendedKeyUsage'
+            ApplicableToClasses = @('pKICertificateTemplate')
+            Description         = 'Can modify pKIExtendedKeyUsage - enables adding authentication EKUs'
+        }
+
+        @{
+            Name                = 'WriteProperty-CertificateApplicationPolicy'
+            Rights              = 'WriteProperty'
+            ObjectTypeGUID      = 'c4e311fc-4e4d-11d1-ab54-00a0c91e9b45'
+            ObjectTypeName      = 'msPKI-Certificate-Application-Policy'
+            ApplicableToClasses = @('pKICertificateTemplate')
+            Description         = 'Can modify msPKI-Certificate-Application-Policy - alternative method to add authentication EKUs'
+        }
+
+        @{
+            Name                = 'WriteProperty-EnrollmentFlag'
+            Rights              = 'WriteProperty'
+            ObjectTypeGUID      = '1ede2375-5dd4-4fca-b62f-75ff65cc1c21'
+            ObjectTypeName      = 'msPKI-Enrollment-Flag'
+            ApplicableToClasses = @('pKICertificateTemplate')
+            Description         = 'Can modify msPKI-Enrollment-Flag - can disable manager approval requirement'
+        }
+
+        @{
+            Name                = 'WriteProperty-RASignature'
+            Rights              = 'WriteProperty'
+            ObjectTypeGUID      = 'fc0a1e69-9b45-11d0-afdd-00c04fd930c9'
+            ObjectTypeName      = 'msPKI-RA-Signature'
+            ApplicableToClasses = @('pKICertificateTemplate')
+            Description         = 'Can modify msPKI-RA-Signature - can reduce authorized signature requirements'
+        }
+
+        @{
+            Name                = 'WriteProperty-MaxIssuingDepth'
+            Rights              = 'WriteProperty'
+            ObjectTypeGUID      = '281416d9-1968-4c91-b96d-6c6d8b7f3e8c'
+            ObjectTypeName      = 'pKIMaxIssuingDepth'
+            ApplicableToClasses = @('pKICertificateTemplate')
+            Description         = 'Can modify pKIMaxIssuingDepth - can enable subordinate CA certificate issuance (ESC5 enabler)'
+        }
+
+        @{
+            Name                = 'WriteProperty-TemplateSchemaVersion'
+            Rights              = 'WriteProperty'
+            ObjectTypeGUID      = '0b9e865e-3b3b-11d2-90cc-00c04fd91ab1'
+            ObjectTypeName      = 'msPKI-Template-Schema-Version'
+            ApplicableToClasses = @('pKICertificateTemplate')
+            Description         = 'Can modify msPKI-Template-Schema-Version - can upgrade template to access additional properties'
+        }
+
+        @{
+            Name                = 'WriteProperty-TemplateMinorRevision'
+            Rights              = 'WriteProperty'
+            ObjectTypeGUID      = '0b9e865f-3b3b-11d2-90cc-00c04fd91ab1'
+            ObjectTypeName      = 'msPKI-Template-Minor-Revision'
+            ApplicableToClasses = @('pKICertificateTemplate')
+            Description         = 'Can modify msPKI-Template-Minor-Revision - can trigger template republication'
+        }
+
+        # ============================================================================
+        # CA-Specific Properties (ESC5a)
+        # ============================================================================
+
+        @{
+            Name                = 'WriteProperty-certificateTemplates'
+            Rights              = 'WriteProperty'
+            ObjectTypeGUID      = 'd15b6a0e-94e5-4a82-8c1a-2765f5cf222f'
+            ObjectTypeName      = 'certificateTemplates'
+            ApplicableToClasses = @('pKIEnrollmentService')
+            Description         = 'Can modify certificateTemplates attribute - can add vulnerable templates to CA publication list or remove security-critical templates'
+        }
+
+        # ============================================================================
+        # Computer-Specific Properties (ESC5a)
+        # ============================================================================
+
+        @{
+            Name                = 'WriteProperty-AllowedToActOnBehalfOfOtherIdentity'
+            Rights              = 'WriteProperty'
+            ObjectTypeGUID      = '3f78c3e5-f79a-46bd-a0b8-9d18116ddc79'
+            ObjectTypeName      = 'msDS-AllowedToActOnBehalfOfOtherIdentity'
+            ApplicableToClasses = @('computer')
+            Description         = 'Can modify msDS-AllowedToActOnBehalfOfOtherIdentity - enables resource-based constrained delegation attacks on CA host'
+        }
+
+        @{
+            Name                = 'WriteProperty-ServicePrincipalName'
+            Rights              = 'WriteProperty'
+            ObjectTypeGUID      = 'f3a64788-5306-11d1-a9c5-0000f80367c1'
+            ObjectTypeName      = 'servicePrincipalName'
+            ApplicableToClasses = @('computer')
+            Description         = 'Can modify servicePrincipalName - can add SPNs for Kerberoasting or impersonation attacks'
+        }
+
+        @{
+            Name                = 'WriteProperty-UserAccountControl'
+            Rights              = 'WriteProperty'
+            ObjectTypeGUID      = 'bf967a68-0de6-11d0-a285-00aa003049e2'
+            ObjectTypeName      = 'userAccountControl'
+            ApplicableToClasses = @('computer')
+            Description         = 'Can modify userAccountControl - can enable TRUSTED_FOR_DELEGATION or disable account security settings'
+        }
+
+        # ============================================================================
+        # Container-Specific Properties (ESC5a)
+        # ============================================================================
+
+        @{
+            Name                = 'CreateChild-All'
+            Rights              = 'CreateChild'
+            ObjectTypeGUID      = $null
+            ObjectTypeName      = $null
+            ApplicableToClasses = @('container')
+            Description         = 'Can create child objects in the container - enables creation of new vulnerable certificate templates or CAs (ESC5a)'
+        }
+
+        @{
+            Name                = 'CreateChild-CertificateTemplate'
+            Rights              = 'CreateChild'
+            ObjectTypeGUID      = 'e5209ca2-3bba-11d2-90cc-00c04fd91ab1'
+            ObjectTypeName      = 'pKICertificateTemplate'
+            ApplicableToClasses = @('container', 'certificationAuthority')
+            Description         = 'Can create certificate template objects in the container - enables creation of new vulnerable certificate templates (ESC5a)'
+        }
+
+        @{
+            Name                = 'WriteProperty-cACertificate'
+            Rights              = 'WriteProperty'
+            ObjectTypeGUID      = 'bf967932-0de6-11d0-a285-00aa003049e2'
+            ObjectTypeName      = 'cACertificate'
+            ApplicableToClasses = @('certificationAuthority')
+            Description         = 'Can modify cACertificate attribute - can add rogue CA certificates to NTAuthCertificates store for enterprise trust (ESC5a)'
+        }
+    )
+}

--- a/Private/Data/ESCDefinitions.ps1
+++ b/Private/Data/ESCDefinitions.ps1
@@ -1,0 +1,627 @@
+$script:ESCDefinitions = data {
+    @{
+        ESC1   = @{
+            # ESC1: Misconfigured Certificate Templates
+            Technique          = 'ESC1'
+
+            # Conditions that make a template vulnerable
+            Conditions         = @(
+                @{ Property = 'SANAllowed'; Value = $true }
+                @{ Property = 'AuthenticationEKUExist'; Value = $true }
+                @{ Property = 'ManagerApprovalNotRequired'; Value = $true }
+                @{ Property = 'AuthorizedSignatureNotRequired'; Value = $true }
+            )
+
+            # Which enrollee properties to check (pre-calculated by Set-* functions)
+            EnrolleeProperties = @(
+                'DangerousEnrollee'
+                'LowPrivilegeEnrollee'
+            )
+
+            # Issue description template (supports variables: $(IdentityReference), $(TemplateName))
+            IssueTemplate      = @(
+                "`$(IdentityReference) can provide a Subject Alternative Name (SAN) while enrolling in this Client "
+                "Authentication template, and enrollment does not require Manager Approval.`n`n"
+                "The resultant certificate can be used by an attacker to authenticate as any principal listed in the SAN "
+                "up to and including Domain Admins, Enterprise Admins, or Domain Controllers.`n`n"
+                "More info:`n"
+                "  - https://posts.specterops.io/certified-pre-owned-d95910965cd2"
+            )
+
+            # Fix script template (supports variable: $(DistinguishedName))
+            FixTemplate        = @(
+                "# Enable Manager Approval"
+                "`$Object = '`$(DistinguishedName)'"
+                "Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}"
+            )
+
+            # Revert script template (supports variable: $(DistinguishedName))
+            RevertTemplate     = @(
+                "# Disable Manager Approval"
+                "`$Object = '`$(DistinguishedName)'"
+                "Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}"
+            )
+        }
+
+        ESC2   = @{
+            Technique          = 'ESC2'
+
+            # Conditions that templates must match to be vulnerable
+            Conditions         = @(
+                @{ Property = 'AnyPurposeEKUExist'; Value = $true }
+                @{ Property = 'ManagerApprovalNotRequired'; Value = $true }
+                @{ Property = 'AuthorizedSignatureNotRequired'; Value = $true }
+            )
+
+            # Properties to check for problematic enrollees
+            EnrolleeProperties = @(
+                'DangerousEnrollee'
+                'LowPrivilegeEnrollee'
+            )
+
+            # Issue description template
+            IssueTemplate      = @(
+                "`$(IdentityReference) can use the `$(TemplateName) template to request any type of certificate - including "
+                "Enrollment Agent certificates and Subordinate Certification Authority (SubCA) certificate - without Manager "
+                "Approval.`n`n"
+                "If an attacker requests an Enrollment Agent certificate and there exists at least one enabled ESC3 Condition 2 "
+                "or ESC15 template available that does not require Manager Approval, the attacker can request a certificate on "
+                "behalf of another principal. The risk presented depends on the privileges granted to the other principal.`n`n"
+                "If an attacker requests a SubCA certificate, the resultant certificate can be used by an attacker to "
+                "instantiate their own SubCA which is trusted by AD.`n`n"
+                "By default, certificates created from this attacker-controlled SubCA cannot be used for authentication, but "
+                "they can be used for other purposes such as TLS certs and code signing."
+            )
+
+            # Remediation script template
+            FixTemplate        = @(
+                "# Enable Manager Approval"
+                "`$Object = '`$(DistinguishedName)'"
+                "Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}"
+            )
+
+            # Revert script template
+            RevertTemplate     = @(
+                "# Disable Manager Approval"
+                "`$Object = '`$(DistinguishedName)'"
+                "Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}"
+            )
+        }
+
+        ESC3c1 = @{
+            Technique          = 'ESC3c1'
+
+            # Conditions that templates must match to be vulnerable
+            Conditions         = @(
+                @{ Property = 'EnrollmentAgentEKUExist'; Value = $true }
+                @{ Property = 'ManagerApprovalNotRequired'; Value = $true }
+                @{ Property = 'AuthorizedSignatureNotRequired'; Value = $true }
+            )
+
+            # Properties to check for problematic enrollees
+            EnrolleeProperties = @(
+                'DangerousEnrollee'
+                'LowPrivilegeEnrollee'
+            )
+
+            # Issue description template
+            IssueTemplate      = @(
+                "`$(IdentityReference) can use the `$(TemplateName) template to request an Enrollment Agent certificate without "
+                "Manager Approval.`n`n"
+                "The resulting certificate can be used to enroll in any template that allows an Enrollment Agent to submit the "
+                "request.`n`n"
+                "More info:`n"
+                "  - https://posts.specterops.io/certified-pre-owned-d95910965cd2"
+            )
+
+            # Remediation script template
+            FixTemplate        = @(
+                "# Enable Manager Approval"
+                "`$Object = '`$(DistinguishedName)'"
+                "Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}"
+            )
+
+            # Revert script template
+            RevertTemplate     = @(
+                "# Disable Manager Approval"
+                "`$Object = '`$(DistinguishedName)'"
+                "Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}"
+            )
+        }
+
+        ESC3c2 = @{
+            Technique          = 'ESC3c2'
+
+            # Conditions that templates must match to be vulnerable
+            Conditions         = @(
+                @{ Property = 'AuthenticationEKUExist'; Value = $true }
+                @{ Property = 'ManagerApprovalNotRequired'; Value = $true }
+                @{ Property = 'RequiresEnrollmentAgentSignature'; Value = $true }
+            )
+
+            # Properties to check for problematic enrollees
+            EnrolleeProperties = @(
+                'DangerousEnrollee'
+                'LowPrivilegeEnrollee'
+            )
+
+            # Issue description template
+            IssueTemplate      = @(
+                "If the holder of a SubCA, Any Purpose, or Enrollment Agent certificate requests a certificate using the "
+                "`$(TemplateName) template, they will receive a certificate which allows them to authenticate as "
+                "`$(IdentityReference).`n`n"
+                "More info:`n"
+                "  - https://posts.specterops.io/certified-pre-owned-d95910965cd2"
+            )
+
+            # Remediation script template
+            FixTemplate        = @(
+                "# First, eliminate unused Enrollment Agent templates."
+                "# Then, tightly scope any Enrollment Agent templates that remain and:"
+                "# Enable Manager Approval"
+                "`$Object = '`$(DistinguishedName)'"
+                "Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}"
+            )
+
+            # Revert script template
+            RevertTemplate     = @(
+                "# Disable Manager Approval"
+                "`$Object = '`$(DistinguishedName)'"
+                "Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}"
+            )
+        }
+
+        ESC9   = @{
+            Technique          = 'ESC9'
+
+            # Conditions that templates must match to be vulnerable
+            Conditions         = @(
+                @{ Property = 'AuthenticationEKUExist'; Value = $true }
+                @{ Property = 'NoSecurityExtension'; Value = $true }
+            )
+
+            # Properties to check for problematic enrollees
+            EnrolleeProperties = @(
+                'DangerousEnrollee'
+                'LowPrivilegeEnrollee'
+            )
+
+            # Issue description template
+            IssueTemplate      = @(
+                "The `$(TemplateName) template has the szOID_NTDS_CA_SECURITY_EXT security extension disabled. "
+                "Certificates issued from this template will not enforce strong certificate binding. Depending on the "
+                "current Certificate Binding Enforcement level ESC6 status, it may be possible to request and receive "
+                "certificates that rely on weak (aka attacker-controllable) binding methods.`n`n"
+                "An attacker can abuse this weakness by:`n"
+                "1. Getting access to a user or computer account.`n"
+                "2. Modifying the user's userPrincipalName attribute (or the computer's dNSHostName attribute) to match a "
+                "higher-privileged account.`n"
+                "3. Requesting a client authentication certificate from this template with szOID_NTDS_CA_SECURITY_EXT disabled.`n"
+                "4. Using the client authentication certificate to authenticate as the higher-privileged account.`n"
+                "5. Profiting.`n`n"
+                "More info:`n"
+                "  - ESC9 description: https://github.com/ly4k/Certipy/wiki/06-%E2%80%90-Privilege-Escalation#esc9-no-security-extension-on-certificate-template`n"
+                "  - Strong Mapping/Enforcement Mode: https://support.microsoft.com/en-us/topic/kb5014754-certificate-based-authentication-changes-on-windows-domain-controllers-ad2c23b0-15d8-4340-a468-4d4f3b188f16"
+            )
+
+            # Remediation script template
+            FixTemplate        = @(
+                "# Enable Manager Approval"
+                "`$Object = '`$(DistinguishedName)'"
+                "Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}"
+            )
+
+            # Revert script template
+            RevertTemplate     = @(
+                "# Disable Manager Approval"
+                "`$Object = '`$(DistinguishedName)'"
+                "Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}"
+            )
+        }
+
+        ESC6   = @{
+            Technique      = 'ESC6'
+
+            # Conditions that CAs must match to be vulnerable
+            Conditions     = @(
+                @{ Property = 'SANFlagEnabled'; Value = $true }
+            )
+
+            # Issue description template
+            IssueTemplate  = @(
+                "The Certification Authority `$(CAName) has the EDITF_ATTRIBUTESUBJECTALTNAME2 flag enabled. "
+                "This allows ANY certificate request to specify Subject Alternative Names (SANs) regardless of "
+                "template configuration.`n`n"
+                "An attacker with enrollment rights to ANY template on this CA can request certificates with "
+                "arbitrary SANs, enabling authentication as any principal (including Domain Admins, Enterprise "
+                "Admins, or Domain Controllers).`n`n"
+                "This setting overrides template-level SAN restrictions and should be disabled unless absolutely "
+                "necessary with strict template controls.`n`n"
+                "More info:`n"
+                "  - https://posts.specterops.io/certified-pre-owned-d95910965cd2"
+            )
+
+            # Remediation script template
+            FixTemplate    = @(
+                "# Disable EDITF_ATTRIBUTESUBJECTALTNAME2 on the CA"
+                "certutil -config `$(CAFullName) -setreg policy\\EditFlags -EDITF_ATTRIBUTESUBJECTALTNAME2"
+                "# Restart Certificate Services for the change to take effect"
+                "Restart-Service -Name CertSvc -Force"
+            )
+
+            # Revert script template
+            RevertTemplate = @(
+                "# Re-enable EDITF_ATTRIBUTESUBJECTALTNAME2 on the CA"
+                "certutil -config `$(CAFullName) -setreg policy\\EditFlags +EDITF_ATTRIBUTESUBJECTALTNAME2"
+                "# Restart Certificate Services"
+                "Restart-Service -Name CertSvc -Force"
+            )
+        }
+
+        ESC11  = @{
+            Technique      = 'ESC11'
+
+            # Conditions that CAs must match to be vulnerable
+            Conditions     = @(
+                @{ Property = 'RPCEncryptionNotRequired'; Value = $true }
+            )
+
+            # Issue description template
+            IssueTemplate  = @(
+                "The Certification Authority `$(CAName) does not require RPC encryption for certificate "
+                "requests (IF_ENFORCEENCRYPTICERTREQUEST flag is disabled).`n`n"
+                "This allows certificate requests to be submitted over unencrypted RPC/DCOM connections, "
+                "which can be intercepted and manipulated via network-based attacks (NTLM relay).`n`n"
+                "An attacker positioned on the network can:`n"
+                "1. Relay NTLM authentication to the CA's RPC interface`n"
+                "2. Request certificates on behalf of the relayed victim`n"
+                "3. Use the obtained certificate to authenticate as the victim`n`n"
+                "This is particularly dangerous when combined with coercion techniques.`n`n"
+                "More info:`n"
+                "  - https://posts.specterops.io/certificates-and-pwnage-and-patches-oh-my-8ae0f4304c1d"
+            )
+
+            # Remediation script template
+            FixTemplate    = @(
+                "# Enable IF_ENFORCEENCRYPTICERTREQUEST on the CA"
+                "certutil -config `$(CAFullName) -setreg CA\\InterfaceFlags +IF_ENFORCEENCRYPTICERTREQUEST"
+                "# Restart Certificate Services"
+                "Restart-Service -Name CertSvc -Force"
+            )
+
+            # Revert script template
+            RevertTemplate = @(
+                "# Disable IF_ENFORCEENCRYPTICERTREQUEST on the CA"
+                "certutil -config `$(CAFullName) -setreg CA\\InterfaceFlags -IF_ENFORCEENCRYPTICERTREQUEST"
+                "# Restart Certificate Services"
+                "Restart-Service -Name CertSvc -Force"
+            )
+        }
+
+        ESC7a  = @{
+            Technique       = 'ESC7a'
+
+            # Properties to check for problematic CA administrators
+            AdminProperties = @(
+                'DangerousCAAdministrator'
+                'LowPrivilegeCAAdministrator'
+            )
+
+            # Issue description template for CA Administrators
+            IssueTemplate   = @(
+                "`$(IdentityReference) has CA Administrator rights on `$(CAName).`n`n"
+                "CA Administrators can manage CA configuration, approve certificate requests, and modify "
+                "security settings. This principal should not have these rights.`n`n"
+                "An attacker with these rights can:`n"
+                "1. Approve pending certificate requests (including malicious ones)`n"
+                "2. Disable manager approval on templates`n"
+                "3. Publish vulnerable certificate templates`n"
+                "4. Modify CA configuration to enable additional attack vectors`n`n"
+                "More info:`n"
+                "  - https://posts.specterops.io/certified-pre-owned-d95910965cd2"
+            )
+
+            # Remediation requires manual review
+            FixTemplate     = @(
+                "# Remove CA Administrator role"
+                "certutil -config `$(CAFullName) -delreg ca\\Security\\Roles\\Administrators\\`$(IdentityReference)"
+                "# Restart Certificate Services"
+                "Restart-Service -Name CertSvc -Force"
+                "# NOTE: Review whether this principal needs these rights before removing"
+            )
+
+            # Revert template
+            RevertTemplate  = @(
+                "# Re-add CA Administrator role"
+                "certutil -config `$(CAFullName) -setreg ca\\Security\\Roles\\Administrators\\`$(IdentityReference) +ManageCA"
+                "# Restart Certificate Services"
+                "Restart-Service -Name CertSvc -Force"
+            )
+        }
+
+        ESC7m  = @{
+            Technique       = 'ESC7m'
+
+            # Properties to check for problematic certificate managers
+            AdminProperties = @(
+                'DangerousCACertificateManager'
+                'LowPrivilegeCACertificateManager'
+            )
+
+            # Issue description template for Certificate Managers
+            IssueTemplate   = @(
+                "`$(IdentityReference) has Certificate Manager rights on `$(CAName).`n`n"
+                "Certificate Managers can approve/deny certificate requests and revoke certificates. "
+                "This principal should not have these rights.`n`n"
+                "An attacker with these rights can approve malicious certificate requests that would "
+                "normally require manager approval.`n`n"
+                "More info:`n"
+                "  - https://posts.specterops.io/certified-pre-owned-d95910965cd2"
+            )
+
+            # Remediation requires manual review
+            FixTemplate     = @(
+                "# Remove Certificate Manager role"
+                "certutil -config `$(CAFullName) -delreg ca\\Security\\Roles\\Officers\\`$(IdentityReference)"
+                "# Restart Certificate Services"
+                "Restart-Service -Name CertSvc -Force"
+                "# NOTE: Review whether this principal needs these rights before removing"
+            )
+
+            # Revert template
+            RevertTemplate  = @(
+                "# Re-add Certificate Manager role"
+                "certutil -config `$(CAFullName) -setreg ca\\Security\\Roles\\Officers\\`$(IdentityReference) +ManageCertificates"
+                "# Restart Certificate Services"
+                "Restart-Service -Name CertSvc -Force"
+            )
+        }
+
+        ESC16  = @{
+            Technique      = 'ESC16'
+
+            # Conditions that CAs must match to be vulnerable
+            Conditions     = @(
+                @{ Property = 'SecurityExtensionDisabled'; Value = $true }
+            )
+
+            # Issue description template
+            IssueTemplate  = @(
+                "The Certification Authority `$(CAName) has disabled the Certificate Template Information extension (OID: 1.3.6.1.4.1.311.25.2).`n`n"
+                "This extension contains critical information about the certificate template used to issue certificates. "
+                "Disabling this extension prevents proper certificate template validation and can allow certificate "
+                "template abuse.`n`n"
+                "When this extension is disabled:`n"
+                "1. Certificate template information is not embedded in issued certificates`n"
+                "2. Template-based security controls cannot be enforced`n"
+                "3. Certificate template identification becomes unreliable`n`n"
+                "This can be exploited to bypass template-level restrictions.`n`n"
+                "More info:`n"
+                "  - https://posts.specterops.io/certificates-and-pwnage-and-patches-oh-my-8ae0f4304c1d"
+            )
+
+            # Remediation script template
+            FixTemplate    = @(
+                "# Re-enable disabled extensions on the CA"
+                "# Remove the extension OIDs from the DisableExtensionList registry value"
+                "certutil -config `$(CAFullName) -delreg policy\\DisableExtensionList"
+                "# Restart Certificate Services"
+                "Restart-Service -Name CertSvc -Force"
+                "# NOTE: Review which extensions should be enabled before applying this fix"
+            )
+
+            # Revert script template
+            RevertTemplate = @(
+                "# Re-disable the extensions (use with caution)"
+                "certutil -config `$(CAFullName) -setreg policy\\DisableExtensionList `$(DisabledExtensions)"
+                "# Restart Certificate Services"
+                "Restart-Service -Name CertSvc -Force"
+            )
+        }
+
+        # ============================================================================
+        # ESC4a: Vulnerable Certificate Template Access Control (ACE-based)
+        # ============================================================================
+        ESC4a  = @{
+            Technique        = 'ESC4a'
+
+            # No conditions - all templates are checked for dangerous ACEs
+            Conditions       = @()
+
+            # Which editor properties to check (pre-calculated by Set-* functions)
+            EditorProperties = @(
+                'DangerousEditor'
+                'LowPrivilegeEditor'
+            )
+
+            # Issue description template
+            IssueTemplate    = @(
+                "`$(IdentityReference) has `$(ActiveDirectoryRights) rights on the '`$(TemplateName)' certificate template.`n`n"
+                "This permission allows the principal to modify template settings without proper authorization. "
+                "Per Microsoft security best practices, only highly privileged administrators (Domain Admins, "
+                "Enterprise Admins) should have write access to certificate templates.`n`n"
+                "An attacker with these permissions can:`n"
+                "1. Modify enrollment permissions (grant themselves enrollment rights)`n"
+                "2. Change template EKUs to enable authentication or code signing`n"
+                "3. Disable security extensions or manager approval requirements`n"
+                "4. Enable subject name flexibility (ENROLLEE_SUPPLIES_SUBJECT)`n"
+                "5. Create ESC1, ESC2, ESC3, or ESC9 conditions on the template`n`n"
+                "More info:`n"
+                "  - https://posts.specterops.io/certified-pre-owned-d95910965cd2"
+            )
+
+            # Remediation script template
+            FixTemplate      = @(
+                "# Remove write permissions for `$(IdentityReference)"
+                "`$Template = [ADSI]'LDAP://`$(DistinguishedName)'"
+                "`$Identity = New-Object System.Security.Principal.NTAccount('`$(IdentityReference)')"
+                "`$TemplateSecurity = `$Template.ObjectSecurity"
+                "# Remove all ACEs for this identity"
+                "`$TemplateSecurity.Access | Where-Object { `$_.IdentityReference -eq `$Identity } | ForEach-Object {"
+                "    `$TemplateSecurity.RemoveAccessRule(`$_) | Out-Null"
+                "}"
+                "`$Template.CommitChanges()"
+            )
+
+            # Revert script template
+            RevertTemplate   = @(
+                "# Manual restoration required - review original ACL and restore appropriate permissions"
+                "# Get-ADObject '`$(DistinguishedName)' -Properties nTSecurityDescriptor"
+            )
+        }
+
+        # ============================================================================
+        # ESC4o: Vulnerable Certificate Template Ownership
+        # ============================================================================
+        ESC4o  = @{
+            Technique      = 'ESC4o'
+
+            # Conditions to identify vulnerable templates
+            Conditions     = @(
+                @{
+                    Property = 'HasNonStandardOwner'
+                    Operator = 'eq'
+                    Value    = $true
+                }
+            )
+
+            # Issue description template
+            IssueTemplate  = @(
+                "The certificate template '`$(TemplateName)' is owned by `$(Owner), which is not a standard owner.`n`n"
+                "Per Microsoft security best practices, certificate templates should be owned exclusively "
+                "by the forest's Enterprise Admins group. Templates with non-standard owners can be exploited "
+                "by the owner to modify critical template properties without proper authorization.`n`n"
+                "An attacker who controls the template owner can:`n"
+                "1. Modify enrollment permissions (grant themselves enrollment rights)`n"
+                "2. Change template EKUs to enable authentication or code signing`n"
+                "3. Disable security extensions or manager approval requirements`n"
+                "4. Enable subject name flexibility (ENROLLEE_SUPPLIES_SUBJECT)`n"
+                "5. Create ESC1, ESC2, ESC3, or ESC9 conditions on the template`n`n"
+                "More info:`n"
+                "  - https://posts.specterops.io/certified-pre-owned-d95910965cd2"
+            )
+
+            # Remediation script template
+            FixTemplate    = @(
+                "# Transfer ownership to Enterprise Admins"
+                "`$Template = [ADSI]'LDAP://`$(DistinguishedName)'"
+                "`$Owner = New-Object System.Security.Principal.NTAccount('Enterprise Admins')"
+                "`$TemplateSecurity = `$Template.ObjectSecurity"
+                "`$TemplateSecurity.SetOwner(`$Owner)"
+                "`$Template.CommitChanges()"
+            )
+
+            # Revert script template
+            RevertTemplate = @(
+                "# Restore original owner"
+                "`$Template = [ADSI]'LDAP://`$(DistinguishedName)'"
+                "`$Owner = New-Object System.Security.Principal.NTAccount('`$(OriginalOwner)')"
+                "`$TemplateSecurity = `$Template.ObjectSecurity"
+                "`$TemplateSecurity.SetOwner(`$Owner)"
+                "`$Template.CommitChanges()"
+            )
+        }
+
+        # ============================================================================
+        # ESC5a: Vulnerable PKI Object Access Control
+        # ============================================================================
+        ESC5a  = @{
+            Technique        = 'ESC5a'
+
+            # Conditions are empty since we check editor properties directly
+            Conditions       = @()
+
+            # Which editor properties to check (pre-calculated by Set-* functions)
+            EditorProperties = @(
+                'DangerousEditor'
+                'LowPrivilegeEditor'
+            )
+
+            # Issue description template
+            IssueTemplate    = @(
+                "`$(IdentityReference) has `$(ActiveDirectoryRights) rights on the '`$(ObjectName)' PKI object.`n`n"
+                "This permission allows the principal to modify PKI infrastructure settings without proper authorization. "
+                "Per Microsoft security best practices, only highly privileged administrators (Domain Admins, "
+                "Enterprise Admins) should have write access to PKI infrastructure objects.`n`n"
+                "An attacker with these permissions can:`n"
+                "1. Modify object permissions (WriteDacl)`n"
+                "2. Grant themselves additional rights`n"
+                "3. For CAs: Modify CA configuration, disable security extensions, grant dangerous permissions`n"
+                "4. For containers: Create vulnerable templates or CAs`n"
+                "5. For computer objects: Modify CA host configuration`n"
+                "6. Manipulate PKI trust relationships and create ESC1, ESC2, ESC3, or ESC4 conditions`n`n"
+                "More info:`n"
+                "  - https://posts.specterops.io/certified-pre-owned-d95910965cd2"
+            )
+
+            # Remediation script template
+            FixTemplate      = @(
+                "# Remove write permissions for `$(IdentityReference)"
+                "`$Object = [ADSI]'LDAP://`$(DistinguishedName)'"
+                "`$Identity = New-Object System.Security.Principal.NTAccount('`$(IdentityReference)')"
+                "`$ObjectSecurity = `$Object.ObjectSecurity"
+                "# Remove all ACEs for this identity"
+                "`$ObjectSecurity.Access | Where-Object { `$_.IdentityReference -eq `$Identity } | ForEach-Object {"
+                "    `$ObjectSecurity.RemoveAccessRule(`$_) | Out-Null"
+                "}"
+                "`$Object.CommitChanges()"
+            )
+
+            # Revert script template
+            RevertTemplate   = @(
+                "# Manual restoration required - review original ACL and restore appropriate permissions"
+                "# Get-ADObject '`$(DistinguishedName)' -Properties nTSecurityDescriptor"
+            )
+        }
+
+        ESC5o  = @{
+            Technique      = 'ESC5o'
+
+            # Conditions to identify vulnerable objects
+            Conditions     = @(
+                @{
+                    Property = 'HasNonStandardOwner'
+                    Operator = 'eq'
+                    Value    = $true
+                }
+            )
+
+            # Issue description template
+            IssueTemplate  = @(
+                "The `$(ObjectType) '`$(ObjectName)' is owned by `$(Owner), which is not a standard owner.`n`n"
+                "Per Microsoft security best practices, AD CS infrastructure objects should be owned exclusively "
+                "by the forest's Enterprise Admins group. Objects with non-standard owners may be vulnerable to "
+                "ESC4-style attacks where the owner can modify security-critical settings.`n`n"
+                "An attacker who controls the owner principal can:`n"
+                "1. Modify object permissions (WriteDacl)`n"
+                "2. Grant themselves additional rights`n"
+                "3. For CAs: Modify CA configuration, disable security extensions, grant dangerous permissions`n"
+                "4. For containers: Create vulnerable templates or CAs`n"
+                "5. For computer objects: Modify CA host configuration`n"
+                "6. Manipulate PKI trust relationships`n`n"
+                "More info:`n"
+                "  - https://posts.specterops.io/certified-pre-owned-d95910965cd2"
+            )
+
+            # Remediation script template
+            FixTemplate    = @(
+                "# Transfer ownership to Enterprise Admins"
+                "`$Object = [ADSI]'LDAP://`$(DistinguishedName)'"
+                "`$Owner = New-Object System.Security.Principal.NTAccount('Enterprise Admins')"
+                "`$ObjectSecurity = `$Object.ObjectSecurity"
+                "`$ObjectSecurity.SetOwner(`$Owner)"
+                "`$Object.CommitChanges()"
+            )
+
+            # Revert script template
+            RevertTemplate = @(
+                "# Restore original owner"
+                "`$Object = [ADSI]'LDAP://`$(DistinguishedName)'"
+                "`$Owner = New-Object System.Security.Principal.NTAccount('`$(OriginalOwner)')"
+                "`$ObjectSecurity = `$Object.ObjectSecurity"
+                "`$ObjectSecurity.SetOwner(`$Owner)"
+                "`$Object.CommitChanges()"
+            )
+        }
+    }
+}

--- a/Private/Data/PrincipalDefinitions.ps1
+++ b/Private/Data/PrincipalDefinitions.ps1
@@ -1,0 +1,146 @@
+<#
+.SYNOPSIS
+Security Principal Definitions for AD CS Security Auditing
+
+.DESCRIPTION
+This PowerShell Data File defines security principal patterns used to classify
+identities in Active Directory Certificate Services security analysis.
+
+Principal Categories:
+
+1. SafePrincipals - High-privilege administrative groups expected to have broad permissions
+   - Domain Admins, Enterprise Admins, SYSTEM, Domain Controllers, etc.
+   - These are considered "safe" to have enrollment and modification permissions
+
+2. DangerousPrincipals - Overly broad groups that should not have enrollment permissions
+   - Everyone, Authenticated Users, Domain Users, Domain Computers, etc.
+   - Grant to these represents privilege escalation risk
+
+3. StandardOwners - Principals that should own AD CS objects
+   - Similar to SafePrincipals but focused on ownership validation
+   - Objects owned by non-standard principals may be vulnerable to ESC4-style attacks
+
+Each array contains SIDs, NTAccount names, and regex patterns for matching.
+Regex patterns (ending in $) enable matching entire SID families (e.g., -512$ matches all Domain Admins groups).
+
+.NOTES
+Common SID Suffixes:
+- -500: Builtin Administrator account
+- -512: Domain Admins group
+- -516: Domain Controllers group
+- -517: Cert Publishers group
+- -518: Schema Admins group
+- -519: Enterprise Admins group
+- -521: Read-Only Domain Controllers group
+- -526: Key Admins group
+- -527: Enterprise Key Admins group
+- -513: Domain Users group
+- -515: Domain Computers group
+- -544: Builtin Administrators group
+- -545: Builtin Users group
+
+Well-Known SIDs:
+- S-1-0-0: NULL SID
+- S-1-1-0: Everyone
+- S-1-5-7: Anonymous Logon
+- S-1-5-10: SELF
+- S-1-5-11: Authenticated Users
+- S-1-5-18: SYSTEM
+- S-1-5-32-544: BUILTIN\Administrators
+- S-1-5-32-545: BUILTIN\Users
+
+.LINK
+https://posts.specterops.io/certified-pre-owned-d95910965cd2
+
+.LINK
+https://learn.microsoft.com/en-us/windows-server/identity/ad-ds/manage/understand-security-identifiers
+#>
+
+$script:PrincipalDefinitionsBase = data {
+    @{
+        # ============================================================================
+        # Safe Principals - High-privilege administrative groups
+        # ============================================================================
+        # These principals are considered safe/expected to have broad permissions
+        # on AD CS objects. Used to filter out expected administrative access.
+
+        SafePrincipals      = @(
+            # Domain administrative groups
+            '-512$'                                        # Domain Admins (all domains)
+            '-519$'                                        # Enterprise Admins (forest root)
+            '-518$'                                        # Schema Admins (forest root)
+            '-517$'                                        # Cert Publishers
+            '-526$'                                        # Key Admins
+            '-527$'                                        # Enterprise Key Admins
+
+            # Builtin administrative groups
+            'S-1-5-32-544'                                 # BUILTIN\Administrators
+            '-544$'                                        # Builtin Administrators (domain-specific)
+            '-500$'                                        # Builtin Administrator account
+
+            # System and service accounts
+            'S-1-5-18'                                     # SYSTEM
+            '-18$'                                         # SYSTEM (pattern match)
+            'NT AUTHORITY\\SYSTEM'                         # SYSTEM (NTAccount format)
+
+            # Domain controller groups
+            '-516$'                                        # Domain Controllers
+            '-521$'                                        # Read-Only Domain Controllers
+            '-498$'                                        # Enterprise Domain Controllers
+            'NT AUTHORITY\\ENTERPRISE DOMAIN CONTROLLERS'  # Enterprise Domain Controllers (NTAccount)
+            '-9$'                                          # Enterprise Read-Only Domain Controllers
+
+            # Special identities
+            'S-1-5-10'                                     # SELF
+            'NT AUTHORITY\\SELF'                           # SELF (NTAccount format)
+        )
+
+        # ============================================================================
+        # Dangerous Principals - Overly broad groups
+        # ============================================================================
+        # These principals represent overly permissive access that should not have
+        # enrollment or modification permissions on AD CS objects. Indicates potential
+        # privilege escalation vulnerabilities (ESC1, ESC2, ESC3, etc.).
+
+        DangerousPrincipals = @(
+            # NULL and universal access
+            'S-1-0-0'                            # NULL SID
+            'S-1-1-0'                            # Everyone
+            'Everyone'                           # Everyone (NTAccount format)
+
+            # Anonymous access
+            'S-1-5-7'                            # Anonymous Logon
+            'NT AUTHORITY\\ANONYMOUS LOGON'      # Anonymous Logon (NTAccount format)
+
+            # Authenticated users (still too broad)
+            'S-1-5-11'                           # Authenticated Users
+            'NT AUTHORITY\\Authenticated Users'  # Authenticated Users (NTAccount format)
+
+            # Builtin broad groups
+            'S-1-5-32-545'                       # BUILTIN\Users
+            'BUILTIN\\Users'                     # BUILTIN\Users (NTAccount format)
+
+            # Domain-wide groups
+            '-513$'                              # Domain Users (all domains)
+            '-515$'                              # Domain Computers (all domains)
+        )
+
+        # ============================================================================
+        # Standard Owners - Principals that should own AD CS objects
+        # ============================================================================
+        # These principals are expected to own certificate templates, CAs, and other
+        # AD CS objects. Objects owned by other principals may be vulnerable to
+        # ESC4-style attacks where the owner can modify security-critical settings.
+        #
+        # Per Microsoft best practices, AD CS objects should be owned exclusively by
+        # Enterprise Admins to prevent privilege escalation through ownership modification.
+        #
+        # Note: The forest-specific Enterprise Admins SID will be dynamically added during
+        # initialization to ensure only THIS forest's Enterprise Admins are considered standard.
+
+        StandardOwners      = @(
+            # Forest-specific Enterprise Admins SID will be added at runtime
+            # Do not use regex patterns like -519$ as they would match Enterprise Admins from other forests
+        )
+    }
+}

--- a/Private/Initialize/Initialize-LS2Scan.ps1
+++ b/Private/Initialize/Initialize-LS2Scan.ps1
@@ -58,6 +58,38 @@ function Initialize-LS2Scan {
 
     #requires -Version 5.1
 
+    # Validate definition data loaded at module import
+    if (-not $script:DangerousAces) {
+        $PSCmdlet.ThrowTerminatingError(
+            [System.Management.Automation.ErrorRecord]::new(
+                [System.InvalidOperationException]::new('DangerousAces definitions not loaded. The module may not have imported correctly.'),
+                'DangerousAcesNotInitialized',
+                [System.Management.Automation.ErrorCategory]::InvalidOperation,
+                $null
+            )
+        )
+    }
+    if (-not $script:ESCDefinitions) {
+        $PSCmdlet.ThrowTerminatingError(
+            [System.Management.Automation.ErrorRecord]::new(
+                [System.InvalidOperationException]::new('ESCDefinitions not loaded. The module may not have imported correctly.'),
+                'ESCDefinitionsNotInitialized',
+                [System.Management.Automation.ErrorCategory]::InvalidOperation,
+                $null
+            )
+        )
+    }
+    if (-not $script:PrincipalDefinitionsBase) {
+        $PSCmdlet.ThrowTerminatingError(
+            [System.Management.Automation.ErrorRecord]::new(
+                [System.InvalidOperationException]::new('PrincipalDefinitionsBase not loaded. The module may not have imported correctly.'),
+                'PrincipalDefinitionsBaseNotInitialized',
+                [System.Management.Automation.ErrorCategory]::InvalidOperation,
+                $null
+            )
+        )
+    }
+
     # Prevent recursive calls during initialization
     if ($script:InitializingStores) {
         return $true

--- a/Private/Initialize/Initialize-PrincipalDefinitions.ps1
+++ b/Private/Initialize/Initialize-PrincipalDefinitions.ps1
@@ -40,23 +40,24 @@ function Initialize-PrincipalDefinitions {
     }
 
     process {
+        if (-not $script:PrincipalDefinitionsBase) {
+            $PSCmdlet.ThrowTerminatingError(
+                [System.Management.Automation.ErrorRecord]::new(
+                    [System.InvalidOperationException]::new('PrincipalDefinitionsBase is not initialized. Cannot load principal definitions.'),
+                    'PrincipalDefinitionsBaseNotInitialized',
+                    [System.Management.Automation.ErrorCategory]::InvalidOperation,
+                    $null
+                )
+            )
+        }
+
         try {
-            # Load the base definitions from PSD1 file
-            # Use $PSScriptRoot which points to Private\Initialize, so go up one level to Private, then into Data
-            $definitionsPath = Join-Path (Split-Path $PSScriptRoot -Parent) 'Data\PrincipalDefinitions.psd1'
-            Write-Verbose "Loading principal definitions from: $definitionsPath"
-            
-            if (-not (Test-Path $definitionsPath)) {
-                throw "Principal definitions file not found at: $definitionsPath"
-            }
-            
-            $definitions = Import-PowerShellDataFile -Path $definitionsPath
-            Write-Verbose "Successfully loaded principal definitions file"
-            
+            Write-Verbose 'Loading principal definitions from $script:PrincipalDefinitionsBase'
+
             # Start with the base definitions
-            $script:SafePrincipals = $definitions.SafePrincipals
-            $script:DangerousPrincipals = $definitions.DangerousPrincipals
-            $script:StandardOwners = $definitions.StandardOwners
+            $script:SafePrincipals      = $script:PrincipalDefinitionsBase.SafePrincipals
+            $script:DangerousPrincipals = $script:PrincipalDefinitionsBase.DangerousPrincipals
+            $script:StandardOwners      = $script:PrincipalDefinitionsBase.StandardOwners
             
             # Inject forest-specific principals
             if ($script:RootDSE -and $script:DomainStore) {

--- a/Private/Test/Test-IsDangerousAce.ps1
+++ b/Private/Test/Test-IsDangerousAce.ps1
@@ -94,21 +94,11 @@ function Test-IsDangerousAce {
     #requires -Version 5.1
 
     begin {
-        # Load dangerous ACE definitions from PSD1 data file
         if (-not $script:DangerousAces) {
-            $dataFilePath = Join-Path $PSScriptRoot '..\Data\AceDefinitions.psd1'
-            
-            if (Test-Path $dataFilePath) {
-                $data = Import-PowerShellDataFile -Path $dataFilePath
-                $script:DangerousAces = $data.DangerousAces
-                Write-Verbose "Loaded $($script:DangerousAces.Count) dangerous ACE definitions from $dataFilePath"
-            } else {
-                Write-Warning "AceDefinitions.psd1 not found at $dataFilePath. Unable to test for dangerous permissions."
-                return
-            }
-        } else {
-            Write-Verbose "Using cached $($script:DangerousAces.Count) dangerous ACE definitions"
+            Write-Warning 'DangerousAces definitions not initialized. Unable to test for dangerous permissions.'
+            return
         }
+        Write-Verbose "Using $($script:DangerousAces.Count) dangerous ACE definitions"
         
         # Filter to ACEs applicable to this object class
         $applicableAces = $script:DangerousAces | Where-Object { $_.ApplicableToClasses -contains $ObjectClass }

--- a/Public/Find-LS2VulnerableCA.ps1
+++ b/Public/Find-LS2VulnerableCA.ps1
@@ -4,7 +4,7 @@ function Find-LS2VulnerableCA {
         Identifies vulnerable AD CS Certification Authorities based on ESC technique definitions.
 
     .DESCRIPTION
-        Reads ESC technique definitions from ESCDefinitions.psd1, queries the AdcsObjectStore
+        Uses ESC technique definitions loaded at module initialization, queries the AdcsObjectStore
         for matching CAs, and generates issues for configuration problems or dangerous role assignments.
         
         ESC6: Detects CAs with EDITF_ATTRIBUTESUBJECTALTNAME2 enabled
@@ -115,12 +115,13 @@ function Find-LS2VulnerableCA {
         return
     }
 
-    # Load all ESC definitions
-    $definitionsPath = Join-Path $PSScriptRoot '..\Private\Data\ESCDefinitions.psd1'
-    $allDefinitions = Import-PowerShellDataFile -Path $definitionsPath
-    $config = $allDefinitions[$Technique]
+    if (-not $script:ESCDefinitions) {
+        Write-Warning 'ESCDefinitions not initialized. Cannot scan for vulnerabilities.'
+        return
+    }
+    $config = $script:ESCDefinitions[$Technique]
 
-    Write-Verbose "Scanning for $Technique using definitions from $definitionsPath"
+    Write-Verbose "Scanning for $Technique"
 
     # Query AdcsObjectStore for CAs
     $allCAs = $script:AdcsObjectStore.Values | Where-Object { $_.objectClass -contains 'pKIEnrollmentService' }

--- a/Public/Find-LS2VulnerableObject.ps1
+++ b/Public/Find-LS2VulnerableObject.ps1
@@ -106,12 +106,13 @@ function Find-LS2VulnerableObject {
         return
     }
 
-    # Load all ESC definitions
-    $definitionsPath = Join-Path $PSScriptRoot '..\Private\Data\ESCDefinitions.psd1'
-    $allDefinitions = Import-PowerShellDataFile -Path $definitionsPath
-    $config = $allDefinitions[$Technique]
+    if (-not $script:ESCDefinitions) {
+        Write-Warning 'ESCDefinitions not initialized. Cannot scan for vulnerabilities.'
+        return
+    }
+    $config = $script:ESCDefinitions[$Technique]
 
-    Write-Verbose "Scanning for $Technique using definitions from $definitionsPath"
+    Write-Verbose "Scanning for $Technique"
 
     # Query AdcsObjectStore for infrastructure objects and CAs (exclude templates only)
     $allObjects = $script:AdcsObjectStore.Values | Where-Object { 

--- a/Public/Find-LS2VulnerableTemplate.ps1
+++ b/Public/Find-LS2VulnerableTemplate.ps1
@@ -4,7 +4,7 @@ function Find-LS2VulnerableTemplate {
         Identifies vulnerable AD CS templates based on ESC technique definitions.
 
     .DESCRIPTION
-        Reads ESC technique definitions from ESCDefinitions.psd1, queries the AdcsObjectStore
+        Uses ESC technique definitions loaded at module initialization, queries the AdcsObjectStore
         for matching templates, and generates issues for problematic enrollees.
 
     .PARAMETER Technique
@@ -99,12 +99,13 @@ function Find-LS2VulnerableTemplate {
         return
     }
 
-    # Load all ESC definitions
-    $definitionsPath = Join-Path $PSScriptRoot '..\Private\Data\ESCDefinitions.psd1'
-    $allDefinitions = Import-PowerShellDataFile -Path $definitionsPath
-    $config = $allDefinitions[$Technique]
+    if (-not $script:ESCDefinitions) {
+        Write-Warning 'ESCDefinitions not initialized. Cannot scan for vulnerabilities.'
+        return
+    }
+    $config = $script:ESCDefinitions[$Technique]
 
-    Write-Verbose "Scanning for $Technique using definitions from $definitionsPath"
+    Write-Verbose "Scanning for $Technique"
 
     # Query AdcsObjectStore for templates, then filter by conditions
     $allTemplates = $script:AdcsObjectStore.Values | Where-Object { $_.IsCertificateTemplate() }

--- a/Tests/Private/Data/AceDefinitions.Tests.ps1
+++ b/Tests/Private/Data/AceDefinitions.Tests.ps1
@@ -3,71 +3,67 @@ BeforeAll {
     $PesterPreference = [PesterConfiguration]::Default
     $PesterPreference.Should.ErrorAction = 'Continue'
 
-    $DataFilePath = Join-Path (Split-Path (Split-Path (Split-Path $PSScriptRoot))) 'Private\Data\AceDefinitions.psd1'
-    $script:Data = Import-PowerShellDataFile -Path $DataFilePath
+    $DataFilePath = Join-Path (Split-Path (Split-Path (Split-Path $PSScriptRoot))) 'Private\Data\AceDefinitions.ps1'
+    . $DataFilePath
 }
 
 Describe 'AceDefinitions data file' -Tag 'Unit', 'Data' {
 
-    Context 'Required top-level keys' {
+    Context 'Required top-level structure' {
 
-        It 'should have a DataVersion key' {
-            $script:Data.ContainsKey('DataVersion') | Should -BeTrue
-        }
-
-        It 'should have a DangerousAces key' {
-            $script:Data.ContainsKey('DangerousAces') | Should -BeTrue
+        It '$script:DangerousAces should be populated after dot-sourcing' {
+            $script:DangerousAces | Should -Not -BeNullOrEmpty
         }
     }
 
     Context 'DangerousAces collection' {
 
         It 'should be an array' {
-            @($script:Data.DangerousAces).Count | Should -BeGreaterThan 0
+            @($script:DangerousAces).Count | Should -BeGreaterThan 0
         }
 
         It 'should contain exactly 20 entries' {
-            @($script:Data.DangerousAces).Count | Should -Be 20
+            @($script:DangerousAces).Count | Should -Be 20
         }
 
         It 'should have no entries with null or empty Name' {
-            foreach ($ace in $script:Data.DangerousAces) {
+            foreach ($ace in $script:DangerousAces) {
                 $ace.Name | Should -Not -BeNullOrEmpty
             }
         }
 
         It 'should have no entries with null or empty Rights' {
-            foreach ($ace in $script:Data.DangerousAces) {
+            foreach ($ace in $script:DangerousAces) {
                 $ace.Rights | Should -Not -BeNullOrEmpty
             }
         }
 
         It 'should have ObjectTypeGUID key present on all entries' {
-            foreach ($ace in $script:Data.DangerousAces) {
+            foreach ($ace in $script:DangerousAces) {
                 $ace.Keys | Should -Contain 'ObjectTypeGUID'
             }
         }
 
         It 'should have ObjectTypeName key present on all entries' {
-            foreach ($ace in $script:Data.DangerousAces) {
+            foreach ($ace in $script:DangerousAces) {
                 $ace.Keys | Should -Contain 'ObjectTypeName'
             }
         }
 
         It 'should have ApplicableToClasses key present on all entries' {
-            foreach ($ace in $script:Data.DangerousAces) {
+            foreach ($ace in $script:DangerousAces) {
                 $ace.Keys | Should -Contain 'ApplicableToClasses'
             }
         }
 
         It 'should have Description key present on all entries' {
-            foreach ($ace in $script:Data.DangerousAces) {
+            foreach ($ace in $script:DangerousAces) {
                 $ace.Keys | Should -Contain 'Description'
             }
         }
 
         It 'should have a non-empty ApplicableToClasses array for all entries' {
-            foreach ($ace in $script:Data.DangerousAces) {
+            foreach ($ace in $script:DangerousAces) {
                 @($ace.ApplicableToClasses).Count | Should -BeGreaterThan 0
             }
         }
@@ -76,42 +72,42 @@ Describe 'AceDefinitions data file' -Tag 'Unit', 'Data' {
     Context 'Named entry spot-checks' {
 
         It 'should contain a GenericAll entry' {
-            $ace = $script:Data.DangerousAces | Where-Object { $_.Name -eq 'GenericAll' }
+            $ace = $script:DangerousAces | Where-Object { $_.Name -eq 'GenericAll' }
             $ace | Should -Not -BeNullOrEmpty
         }
 
         It 'GenericAll entry should have Rights set to GenericAll' {
-            $ace = $script:Data.DangerousAces | Where-Object { $_.Name -eq 'GenericAll' }
+            $ace = $script:DangerousAces | Where-Object { $_.Name -eq 'GenericAll' }
             $ace.Rights | Should -Be 'GenericAll'
         }
 
         It 'GenericAll entry should apply to pKICertificateTemplate class' {
-            $ace = $script:Data.DangerousAces | Where-Object { $_.Name -eq 'GenericAll' }
+            $ace = $script:DangerousAces | Where-Object { $_.Name -eq 'GenericAll' }
             $ace.ApplicableToClasses | Should -Contain 'pKICertificateTemplate'
         }
 
         It 'should contain a WriteDacl entry' {
-            $ace = $script:Data.DangerousAces | Where-Object { $_.Name -eq 'WriteDacl' }
+            $ace = $script:DangerousAces | Where-Object { $_.Name -eq 'WriteDacl' }
             $ace | Should -Not -BeNullOrEmpty
         }
 
         It 'should contain a WriteOwner entry' {
-            $ace = $script:Data.DangerousAces | Where-Object { $_.Name -eq 'WriteOwner' }
+            $ace = $script:DangerousAces | Where-Object { $_.Name -eq 'WriteOwner' }
             $ace | Should -Not -BeNullOrEmpty
         }
 
         It 'should contain a WriteProperty-CertificateNameFlag entry' {
-            $ace = $script:Data.DangerousAces | Where-Object { $_.Name -eq 'WriteProperty-CertificateNameFlag' }
+            $ace = $script:DangerousAces | Where-Object { $_.Name -eq 'WriteProperty-CertificateNameFlag' }
             $ace | Should -Not -BeNullOrEmpty
         }
 
         It 'should contain a CreateChild-CertificateTemplate entry' {
-            $ace = $script:Data.DangerousAces | Where-Object { $_.Name -eq 'CreateChild-CertificateTemplate' }
+            $ace = $script:DangerousAces | Where-Object { $_.Name -eq 'CreateChild-CertificateTemplate' }
             $ace | Should -Not -BeNullOrEmpty
         }
 
         It 'should contain a WriteProperty-cACertificate entry' {
-            $ace = $script:Data.DangerousAces | Where-Object { $_.Name -eq 'WriteProperty-cACertificate' }
+            $ace = $script:DangerousAces | Where-Object { $_.Name -eq 'WriteProperty-cACertificate' }
             $ace | Should -Not -BeNullOrEmpty
         }
     }
@@ -142,14 +138,14 @@ Describe 'AceDefinitions data file' -Tag 'Unit', 'Data' {
         )
 
         It 'should contain all 20 expected ACE names' {
-            $actualNames = $script:Data.DangerousAces | Select-Object -ExpandProperty Name
+            $actualNames = $script:DangerousAces | Select-Object -ExpandProperty Name
             foreach ($name in $expectedNames) {
                 $actualNames | Should -Contain $name
             }
         }
 
         It 'should have no duplicate ACE names' {
-            $names = $script:Data.DangerousAces | Select-Object -ExpandProperty Name
+            $names = $script:DangerousAces | Select-Object -ExpandProperty Name
             $uniqueNames = $names | Select-Object -Unique
             @($uniqueNames).Count | Should -Be @($names).Count
         }

--- a/Tests/Private/Data/ESCDefinitions.Tests.ps1
+++ b/Tests/Private/Data/ESCDefinitions.Tests.ps1
@@ -1,10 +1,10 @@
 #requires -Version 5.1
 BeforeAll {
-    $DataPath = Join-Path (Split-Path (Split-Path (Split-Path $PSScriptRoot))) 'Private\Data\ESCDefinitions.psd1'
-    $script:Definitions = Import-PowerShellDataFile -Path $DataPath
+    $DataPath = Join-Path (Split-Path (Split-Path (Split-Path $PSScriptRoot))) 'Private\Data\ESCDefinitions.ps1'
+    . $DataPath
 }
 
-Describe 'ESCDefinitions.psd1' -Tag 'Unit' {
+Describe 'ESCDefinitions data' -Tag 'Unit' {
     BeforeAll {
         # Report all failures in this describe block rather than stopping at the first
         $PesterPreference = [PesterConfiguration]::Default
@@ -12,11 +12,11 @@ Describe 'ESCDefinitions.psd1' -Tag 'Unit' {
     }
 
     It 'should import without error' {
-        $script:Definitions | Should -Not -BeNullOrEmpty
+        $script:ESCDefinitions | Should -Not -BeNullOrEmpty
     }
 
     It 'should be a hashtable' {
-        $script:Definitions | Should -BeOfType [hashtable]
+        $script:ESCDefinitions | Should -BeOfType [hashtable]
     }
 
     Context 'Required techniques are present' {
@@ -29,7 +29,7 @@ Describe 'ESCDefinitions.psd1' -Tag 'Unit' {
         )
 
         It 'should contain technique <_>' -ForEach $RequiredTechniques {
-            $script:Definitions.Keys | Should -Contain $_
+            $script:ESCDefinitions.Keys | Should -Contain $_
         }
     }
 
@@ -43,23 +43,23 @@ Describe 'ESCDefinitions.psd1' -Tag 'Unit' {
         )
 
         It '<_> should have a Technique key' -ForEach $RequiredTechniques {
-            $script:Definitions[$_].Keys | Should -Contain 'Technique'
+            $script:ESCDefinitions[$_].Keys | Should -Contain 'Technique'
         }
 
         It '<_> should have an IssueTemplate key' -ForEach $RequiredTechniques {
-            $script:Definitions[$_].Keys | Should -Contain 'IssueTemplate'
+            $script:ESCDefinitions[$_].Keys | Should -Contain 'IssueTemplate'
         }
 
         It '<_> should have a FixTemplate key' -ForEach $RequiredTechniques {
-            $script:Definitions[$_].Keys | Should -Contain 'FixTemplate'
+            $script:ESCDefinitions[$_].Keys | Should -Contain 'FixTemplate'
         }
 
         It '<_> should have a RevertTemplate key' -ForEach $RequiredTechniques {
-            $script:Definitions[$_].Keys | Should -Contain 'RevertTemplate'
+            $script:ESCDefinitions[$_].Keys | Should -Contain 'RevertTemplate'
         }
 
         It '<_> Technique property should match its key' -ForEach $RequiredTechniques {
-            $script:Definitions[$_].Technique | Should -Be $_
+            $script:ESCDefinitions[$_].Technique | Should -Be $_
         }
     }
 
@@ -67,17 +67,17 @@ Describe 'ESCDefinitions.psd1' -Tag 'Unit' {
         $TechniquesWithConditions = @('ESC1', 'ESC2', 'ESC3c1', 'ESC3c2', 'ESC9')
 
         It '<_> should have a non-empty Conditions array' -ForEach $TechniquesWithConditions {
-            $script:Definitions[$_].Conditions | Should -Not -BeNullOrEmpty
+            $script:ESCDefinitions[$_].Conditions | Should -Not -BeNullOrEmpty
         }
 
         It 'every Condition in <_> should have a Property key' -ForEach $TechniquesWithConditions {
-            foreach ($condition in $script:Definitions[$_].Conditions) {
+            foreach ($condition in $script:ESCDefinitions[$_].Conditions) {
                 $condition.Keys | Should -Contain 'Property' -Because "condition '$($condition | Out-String)' is missing Property"
             }
         }
 
         It 'every Condition in <_> should have a Value key' -ForEach $TechniquesWithConditions {
-            foreach ($condition in $script:Definitions[$_].Conditions) {
+            foreach ($condition in $script:ESCDefinitions[$_].Conditions) {
                 $condition.Keys | Should -Contain 'Value' -Because "condition '$($condition | Out-String)' is missing Value"
             }
         }
@@ -93,15 +93,15 @@ Describe 'ESCDefinitions.psd1' -Tag 'Unit' {
         )
 
         It '<_> IssueTemplate should not be null or empty' -ForEach $AllTechniques {
-            $script:Definitions[$_].IssueTemplate | Should -Not -BeNullOrEmpty
+            $script:ESCDefinitions[$_].IssueTemplate | Should -Not -BeNullOrEmpty
         }
 
         It '<_> FixTemplate should not be null or empty' -ForEach $AllTechniques {
-            $script:Definitions[$_].FixTemplate | Should -Not -BeNullOrEmpty
+            $script:ESCDefinitions[$_].FixTemplate | Should -Not -BeNullOrEmpty
         }
 
         It '<_> RevertTemplate should not be null or empty' -ForEach $AllTechniques {
-            $script:Definitions[$_].RevertTemplate | Should -Not -BeNullOrEmpty
+            $script:ESCDefinitions[$_].RevertTemplate | Should -Not -BeNullOrEmpty
         }
     }
 }

--- a/Tests/Private/Data/PrincipalDefinitions.Tests.ps1
+++ b/Tests/Private/Data/PrincipalDefinitions.Tests.ps1
@@ -3,159 +3,152 @@ BeforeAll {
     $PesterPreference = [PesterConfiguration]::Default
     $PesterPreference.Should.ErrorAction = 'Continue'
 
-    $DataFilePath = Join-Path (Split-Path (Split-Path (Split-Path $PSScriptRoot))) 'Private\Data\PrincipalDefinitions.psd1'
-    $script:Data = Import-PowerShellDataFile -Path $DataFilePath
+    $DataFilePath = Join-Path (Split-Path (Split-Path (Split-Path $PSScriptRoot))) 'Private\Data\PrincipalDefinitions.ps1'
+    . $DataFilePath
 }
 
 Describe 'PrincipalDefinitions data file' -Tag 'Unit', 'Data' {
 
-    Context 'Required top-level keys' {
+    Context 'Required top-level structure' {
 
-        It 'should have a DataVersion key' {
-            $script:Data.ContainsKey('DataVersion') | Should -BeTrue
+        It '$script:PrincipalDefinitionsBase should be populated after dot-sourcing' {
+            $script:PrincipalDefinitionsBase | Should -Not -BeNullOrEmpty
         }
 
         It 'should have a SafePrincipals key' {
-            $script:Data.ContainsKey('SafePrincipals') | Should -BeTrue
+            $script:PrincipalDefinitionsBase.ContainsKey('SafePrincipals') | Should -BeTrue
         }
 
         It 'should have a DangerousPrincipals key' {
-            $script:Data.ContainsKey('DangerousPrincipals') | Should -BeTrue
+            $script:PrincipalDefinitionsBase.ContainsKey('DangerousPrincipals') | Should -BeTrue
         }
 
         It 'should have a StandardOwners key' {
-            $script:Data.ContainsKey('StandardOwners') | Should -BeTrue
-        }
-    }
-
-    Context 'DataVersion' {
-
-        It 'should have DataVersion equal to 1.0' {
-            $script:Data.DataVersion | Should -Be '1.0'
+            $script:PrincipalDefinitionsBase.ContainsKey('StandardOwners') | Should -BeTrue
         }
     }
 
     Context 'SafePrincipals' {
 
         It 'should be an array' {
-            $script:Data.SafePrincipals | Should -BeOfType [object]
-            @($script:Data.SafePrincipals).Count | Should -BeGreaterThan 0
+            $script:PrincipalDefinitionsBase.SafePrincipals | Should -BeOfType [object]
+            @($script:PrincipalDefinitionsBase.SafePrincipals).Count | Should -BeGreaterThan 0
         }
 
         It 'should contain exactly 19 entries' {
-            @($script:Data.SafePrincipals).Count | Should -Be 19
+            @($script:PrincipalDefinitionsBase.SafePrincipals).Count | Should -Be 19
         }
 
         It 'should contain the Domain Admins RID pattern (-512$)' {
-            $script:Data.SafePrincipals | Should -Contain '-512$'
+            $script:PrincipalDefinitionsBase.SafePrincipals | Should -Contain '-512$'
         }
 
         It 'should contain the Enterprise Admins RID pattern (-519$)' {
-            $script:Data.SafePrincipals | Should -Contain '-519$'
+            $script:PrincipalDefinitionsBase.SafePrincipals | Should -Contain '-519$'
         }
 
         It 'should contain the Schema Admins RID pattern (-518$)' {
-            $script:Data.SafePrincipals | Should -Contain '-518$'
+            $script:PrincipalDefinitionsBase.SafePrincipals | Should -Contain '-518$'
         }
 
         It 'should contain the local Administrators SID (S-1-5-32-544)' {
-            $script:Data.SafePrincipals | Should -Contain 'S-1-5-32-544'
+            $script:PrincipalDefinitionsBase.SafePrincipals | Should -Contain 'S-1-5-32-544'
         }
 
         It 'should contain the Local System SID (S-1-5-18)' {
-            $script:Data.SafePrincipals | Should -Contain 'S-1-5-18'
+            $script:PrincipalDefinitionsBase.SafePrincipals | Should -Contain 'S-1-5-18'
         }
 
         It 'should contain the NT AUTHORITY\SELF SID (S-1-5-10)' {
-            $script:Data.SafePrincipals | Should -Contain 'S-1-5-10'
+            $script:PrincipalDefinitionsBase.SafePrincipals | Should -Contain 'S-1-5-10'
         }
 
         It 'should contain NT AUTHORITY\\SYSTEM NTAccount name' {
-            $script:Data.SafePrincipals | Should -Contain 'NT AUTHORITY\\SYSTEM'
+            $script:PrincipalDefinitionsBase.SafePrincipals | Should -Contain 'NT AUTHORITY\\SYSTEM'
         }
 
         It 'should contain NT AUTHORITY\\SELF NTAccount name' {
-            $script:Data.SafePrincipals | Should -Contain 'NT AUTHORITY\\SELF'
+            $script:PrincipalDefinitionsBase.SafePrincipals | Should -Contain 'NT AUTHORITY\\SELF'
         }
 
         It 'should contain NT AUTHORITY\\ENTERPRISE DOMAIN CONTROLLERS NTAccount name' {
-            $script:Data.SafePrincipals | Should -Contain 'NT AUTHORITY\\ENTERPRISE DOMAIN CONTROLLERS'
+            $script:PrincipalDefinitionsBase.SafePrincipals | Should -Contain 'NT AUTHORITY\\ENTERPRISE DOMAIN CONTROLLERS'
         }
     }
 
     Context 'DangerousPrincipals' {
 
         It 'should be an array' {
-            $script:Data.DangerousPrincipals | Should -BeOfType [object]
+            $script:PrincipalDefinitionsBase.DangerousPrincipals | Should -BeOfType [object]
         }
 
         It 'should contain exactly 11 entries' {
-            @($script:Data.DangerousPrincipals).Count | Should -Be 11
+            @($script:PrincipalDefinitionsBase.DangerousPrincipals).Count | Should -Be 11
         }
 
         It 'should contain the NULL SID (S-1-0-0)' {
-            $script:Data.DangerousPrincipals | Should -Contain 'S-1-0-0'
+            $script:PrincipalDefinitionsBase.DangerousPrincipals | Should -Contain 'S-1-0-0'
         }
 
         It 'should contain the Everyone SID (S-1-1-0)' {
-            $script:Data.DangerousPrincipals | Should -Contain 'S-1-1-0'
+            $script:PrincipalDefinitionsBase.DangerousPrincipals | Should -Contain 'S-1-1-0'
         }
 
         It 'should contain Everyone NTAccount name' {
-            $script:Data.DangerousPrincipals | Should -Contain 'Everyone'
+            $script:PrincipalDefinitionsBase.DangerousPrincipals | Should -Contain 'Everyone'
         }
 
         It 'should contain the Anonymous Logon SID (S-1-5-7)' {
-            $script:Data.DangerousPrincipals | Should -Contain 'S-1-5-7'
+            $script:PrincipalDefinitionsBase.DangerousPrincipals | Should -Contain 'S-1-5-7'
         }
 
         It 'should contain NT AUTHORITY\\ANONYMOUS LOGON NTAccount name' {
-            $script:Data.DangerousPrincipals | Should -Contain 'NT AUTHORITY\\ANONYMOUS LOGON'
+            $script:PrincipalDefinitionsBase.DangerousPrincipals | Should -Contain 'NT AUTHORITY\\ANONYMOUS LOGON'
         }
 
         It 'should contain the Authenticated Users SID (S-1-5-11)' {
-            $script:Data.DangerousPrincipals | Should -Contain 'S-1-5-11'
+            $script:PrincipalDefinitionsBase.DangerousPrincipals | Should -Contain 'S-1-5-11'
         }
 
         It 'should contain NT AUTHORITY\\Authenticated Users NTAccount name' {
-            $script:Data.DangerousPrincipals | Should -Contain 'NT AUTHORITY\\Authenticated Users'
+            $script:PrincipalDefinitionsBase.DangerousPrincipals | Should -Contain 'NT AUTHORITY\\Authenticated Users'
         }
 
         It 'should contain the BUILTIN\\Users SID (S-1-5-32-545)' {
-            $script:Data.DangerousPrincipals | Should -Contain 'S-1-5-32-545'
+            $script:PrincipalDefinitionsBase.DangerousPrincipals | Should -Contain 'S-1-5-32-545'
         }
 
         It 'should contain BUILTIN\\Users NTAccount name' {
-            $script:Data.DangerousPrincipals | Should -Contain 'BUILTIN\\Users'
+            $script:PrincipalDefinitionsBase.DangerousPrincipals | Should -Contain 'BUILTIN\\Users'
         }
 
         It 'should contain the Domain Users RID pattern (-513$)' {
-            $script:Data.DangerousPrincipals | Should -Contain '-513$'
+            $script:PrincipalDefinitionsBase.DangerousPrincipals | Should -Contain '-513$'
         }
 
         It 'should contain the Domain Computers RID pattern (-515$)' {
-            $script:Data.DangerousPrincipals | Should -Contain '-515$'
+            $script:PrincipalDefinitionsBase.DangerousPrincipals | Should -Contain '-515$'
         }
     }
 
     Context 'StandardOwners' {
 
         It 'should be initially empty (runtime-populated by forest Enterprise Admins SID)' {
-            @($script:Data.StandardOwners).Count | Should -Be 0
+            @($script:PrincipalDefinitionsBase.StandardOwners).Count | Should -Be 0
         }
     }
 
     Context 'Cross-contamination guards' {
 
         It 'should not have any DangerousPrincipals entries in SafePrincipals' {
-            foreach ($dangerous in $script:Data.DangerousPrincipals) {
-                $script:Data.SafePrincipals | Should -Not -Contain $dangerous
+            foreach ($dangerous in $script:PrincipalDefinitionsBase.DangerousPrincipals) {
+                $script:PrincipalDefinitionsBase.SafePrincipals | Should -Not -Contain $dangerous
             }
         }
 
         It 'should not have any SafePrincipals entries in DangerousPrincipals' {
-            foreach ($safe in $script:Data.SafePrincipals) {
-                $script:Data.DangerousPrincipals | Should -Not -Contain $safe
+            foreach ($safe in $script:PrincipalDefinitionsBase.SafePrincipals) {
+                $script:PrincipalDefinitionsBase.DangerousPrincipals | Should -Not -Contain $safe
             }
         }
     }

--- a/Tests/Private/Initialize/Initialize-PrincipalDefinitions.Tests.ps1
+++ b/Tests/Private/Initialize/Initialize-PrincipalDefinitions.Tests.ps1
@@ -12,11 +12,16 @@ Describe 'Initialize-PrincipalDefinitions' -Tag 'Unit' {
     InModuleScope 'Locksmith2' {
 
         BeforeEach {
-            $script:SafePrincipals      = @()
-            $script:DangerousPrincipals = @()
-            $script:StandardOwners      = @()
-            $script:RootDSE             = $null
-            $script:DomainStore         = @{}
+            $savedPrincipalDefinitionsBase = $script:PrincipalDefinitionsBase
+            $script:SafePrincipals         = @()
+            $script:DangerousPrincipals    = @()
+            $script:StandardOwners         = @()
+            $script:RootDSE                = $null
+            $script:DomainStore            = @{}
+        }
+
+        AfterEach {
+            $script:PrincipalDefinitionsBase = $savedPrincipalDefinitionsBase
         }
 
         Context 'Successful file load — without RootDSE/DomainStore' {
@@ -113,14 +118,9 @@ Describe 'Initialize-PrincipalDefinitions' -Tag 'Unit' {
         }
 
         Context 'Error resilience' {
-            It 'should initialise arrays to empty rather than leaving them null when data file is missing' {
-                Mock 'Test-Path' { $false }
-                Initialize-PrincipalDefinitions
-                # Piping @() into Should loses the value (empty pipeline = $null to Pester).
-                # Use -is [array] piped via a scalar $true/$false comparison instead.
-                ($script:SafePrincipals      -is [array]) | Should -Be $true -Because 'fallback initialises to @()'
-                ($script:DangerousPrincipals -is [array]) | Should -Be $true -Because 'fallback initialises to @()'
-                ($script:StandardOwners      -is [array]) | Should -Be $true -Because 'fallback initialises to @()'
+            It 'should throw when $script:PrincipalDefinitionsBase is not initialized' {
+                $script:PrincipalDefinitionsBase = $null
+                { Initialize-PrincipalDefinitions } | Should -Throw
             }
         }
     }

--- a/Tests/Private/Test/Test-IsDangerousAce.Tests.ps1
+++ b/Tests/Private/Test/Test-IsDangerousAce.Tests.ps1
@@ -40,10 +40,6 @@ Describe 'Test-IsDangerousAce' -Tag 'Unit' {
             }
         }
 
-        BeforeEach {
-            $script:DangerousAces = $null
-        }
-
         Context 'Return type and shape' {
 
             It 'should return a [PSCustomObject]' {
@@ -173,14 +169,26 @@ Describe 'Test-IsDangerousAce' -Tag 'Unit' {
         }
 
         Context 'Caching behaviour' {
+            BeforeEach {
+                $savedDangerousAces = $script:DangerousAces
+            }
 
-            It 'should populate $script:DangerousAces after first call' {
-                $script:DangerousAces = $null
-                New-MockAce -Rights GenericRead | Test-IsDangerousAce -ObjectClass 'pKICertificateTemplate' | Out-Null
+            AfterEach {
+                $script:DangerousAces = $savedDangerousAces
+            }
+
+            It '$script:DangerousAces should be populated at module load time' {
                 $script:DangerousAces | Should -Not -BeNullOrEmpty
             }
 
-            It 'should use an existing $script:DangerousAces cache instead of reloading from file' {
+            It 'should emit a warning and return IsDangerous=$false when $script:DangerousAces is null' {
+                $script:DangerousAces = $null
+                $ace = New-MockAce -Rights GenericAll
+                $result = $ace | Test-IsDangerousAce -ObjectClass 'pKICertificateTemplate' -WarningAction SilentlyContinue
+                $result.IsDangerous | Should -BeFalse
+            }
+
+            It 'should use a custom $script:DangerousAces value when set' {
                 $script:DangerousAces = @(
                     @{
                         Name                = 'GenericAll'


### PR DESCRIPTION
## Why

PSPublishModule's `MergeModuleOnBuild` merges `.ps1` files into the compiled `.psm1` but silently drops `.psd1` data files, causing `$script:DangerousAces`, `$script:ESCDefinitions`, and `$script:PrincipalDefinitionsBase` to be undefined at runtime in built module artefacts.

## What changed

### New files
- `Private/Data/AceDefinitions.ps1` — replaces `AceDefinitions.psd1`; assigns `$script:DangerousAces` via a `data {}` block at module load time
- `Private/Data/ESCDefinitions.ps1` — replaces `ESCDefinitions.psd1`; assigns `$script:ESCDefinitions`
- `Private/Data/PrincipalDefinitions.ps1` — replaces `PrincipalDefinitions.psd1`; assigns `$script:PrincipalDefinitionsBase`

### Updated consumers
- `Private/Test/Test-IsDangerousAce.ps1` — reads `$script:DangerousAces` directly instead of loading from file
- `Private/Initialize/Initialize-PrincipalDefinitions.ps1` — reads `$script:PrincipalDefinitionsBase`; fail-fast guard moved before `try/catch` using `$PSCmdlet.ThrowTerminatingError()`
- `Public/Find-LS2VulnerableTemplate.ps1`, `Find-LS2VulnerableObject.ps1`, `Find-LS2VulnerableCA.ps1` — removed inline `Import-PowerShellDataFile` calls; read `$script:ESCDefinitions` directly
- `Private/Initialize/Initialize-LS2Scan.ps1` — fail-fast guards for all three `$script:` vars using `$PSCmdlet.ThrowTerminatingError()`
- `Build/Build-Module.ps1` — removed `New-ConfigurationInformation -IncludeAll 'Private\Data'`; `.ps1` files are now merged automatically

### Updated tests
- `Tests/Private/Data/*.Tests.ps1` — dot-source `.ps1` instead of `Import-PowerShellDataFile`; removed `DataVersion` key assertions; updated variable references
- `Tests/Private/Initialize/Initialize-PrincipalDefinitions.Tests.ps1` — error resilience test updated to verify `ThrowTerminatingError` behavior; `AfterEach` added to restore `$script:PrincipalDefinitionsBase`
- `Tests/Private/Test/Test-IsDangerousAce.Tests.ps1` — save/restore of `$script:DangerousAces` scoped to the `Caching behaviour` context only; caching tests updated to reflect module-load-time initialization

## Test results

221/221 passing locally on `refactor/data-psd1-to-ps1`.

## Notes

The old `.psd1` files are still present and will be removed in a follow-up once the build artefact is verified.