### PR TITLE
fix(build): publish from artefact path to include vendored deps

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -159,47 +159,23 @@ Build-Module -ModuleName 'Locksmith2' {
     New-ConfigurationArtefact -Type Unpacked -Enable -Path "$PSScriptRoot\..\Artefacts\Unpacked" #-RequiredModulesPath "$PSScriptRoot\..\Artefacts\Modules"
     New-ConfigurationArtefact -Type Packed -Enable -Path "$PSScriptRoot\..\Artefacts\Packed" -IncludeTagName
 
-    # global options for publishing to github/psgallery
-    if ($PublishToPSGallery) {
-        if ($PSGalleryAPIKey) {
-            # Use API key directly (from environment variable in CI)
-            New-ConfigurationPublish -Type PowerShellGallery -ApiKey $PSGalleryAPIKey -Enabled:$true
-        } elseif ($PSGalleryAPIPath) {
-            # Use API key from file (for local development)
-            New-ConfigurationPublish -Type PowerShellGallery -FilePath $PSGalleryAPIPath -Enabled:$true
-        } else {
-            Write-Error "PublishToPSGallery specified but neither PSGalleryAPIKey nor PSGalleryAPIPath provided."
-        }
-    }
 }
 
-# ── Post-build: vendor PSWriteHTML and PSCertutil into the artefact ──────────
-# PSPublishModule has already written Artefacts\Unpacked\Locksmith2\ by this point.
-# We copy each dependency into a Modules\ subfolder and patch NestedModules.
-$artefactRoot  = Join-Path $PSScriptRoot '..\Artefacts\Unpacked\Locksmith2'
-$modulesTarget = Join-Path $artefactRoot 'Modules'
-New-Item -ItemType Directory -Path $modulesTarget -Force | Out-Null
+# NOTE: Publishing is intentionally NOT configured inside Build-Module {}.
+# PSPublishModule's Publish-Module call uses -Name (resolves from PSModulePath),
+# which publishes the pre-vendoring copy of the module and excludes PSWriteHTML
+# and PSCertutil. We publish via -Path after vendoring instead (see below).
 
-$nestedEntries = @()
-# Pin versions here. Set a value to $null to always pull latest from PSGallery.
-$vendorVersions = @{
-    PSWriteHTML = '1.41.0'
-    PSCertutil  = '0.0.3'
+# ── Post-build: vendor deps and optionally publish from artefact path ─────────
+# Vendoring and publishing are deliberately deferred until after Build-Module {}
+# so that Publish-Module -Path sees the fully patched artefact directory.
+. "$PSScriptRoot\Invoke-LS2PostBuildPublish.ps1"
+
+$postBuildParams = @{
+    ArtefactRoot      = Join-Path $PSScriptRoot '..\Artefacts\Unpacked\Locksmith2'
+    PublishToPSGallery = $PublishToPSGallery
 }
+if ($PSGalleryAPIKey) { $postBuildParams['PSGalleryAPIKey'] = $PSGalleryAPIKey }
+if ($PSGalleryAPIPath) { $postBuildParams['PSGalleryAPIPath'] = $PSGalleryAPIPath }
 
-foreach ($depName in $vendorVersions.Keys) {
-    $pinned = $vendorVersions[$depName]
-    $saveParams = @{ Name = $depName; Path = $modulesTarget; Force = $true }
-    if ($pinned) { $saveParams['RequiredVersion'] = $pinned }
-    Write-Host "Saving $depName$(if ($pinned) { " $pinned" } else { ' (latest)' }) from PSGallery..."
-    Save-Module @saveParams
-    $ver = (Get-ChildItem (Join-Path $modulesTarget $depName) |
-        Sort-Object Name -Descending |
-        Select-Object -First 1).Name
-    Write-Host "Vendored $depName $ver from PSGallery."
-    $nestedEntries += "Modules\$depName\$ver\$depName.psm1"
-}
-
-$psd1 = Join-Path $artefactRoot 'Locksmith2.psd1'
-Update-ModuleManifest -Path $psd1 -NestedModules $nestedEntries
-Write-Host "Locksmith2.psd1 patched: NestedModules = $($nestedEntries -join ', ')"
+Invoke-LS2PostBuildPublish @postBuildParams

--- a/Build/Invoke-LS2PostBuildPublish.ps1
+++ b/Build/Invoke-LS2PostBuildPublish.ps1
@@ -1,0 +1,112 @@
+function Invoke-LS2PostBuildPublish {
+    <#
+    .SYNOPSIS
+    Vendors PSWriteHTML and PSCertutil into the unpacked artefact and optionally publishes to PSGallery.
+
+    .DESCRIPTION
+    Copies pinned versions of PSWriteHTML and PSCertutil into the Modules\ subfolder of the
+    unpacked artefact, patches NestedModules in the PSD1, then — if requested — publishes
+    directly from the artefact path so that the vendored dependencies are included.
+
+    Publishing via -Path bypasses PSModulePath, ensuring what ships to PSGallery matches
+    exactly what is in the artefact directory rather than whatever PSPublishModule installed
+    into the local module store during the build phase.
+
+    .PARAMETER ArtefactRoot
+    Full path to the unpacked module artefact directory (contains Locksmith2.psd1).
+
+    .PARAMETER PublishToPSGallery
+    When present, publishes the module to PSGallery after vendoring.
+
+    .PARAMETER PSGalleryAPIKey
+    NuGet API key in clear text. Used when running in CI via a secret environment variable.
+
+    .PARAMETER PSGalleryAPIPath
+    Path to a file containing the NuGet API key. Used for local developer workflows.
+
+    .EXAMPLE
+    Invoke-LS2PostBuildPublish -ArtefactRoot '.\Artefacts\Unpacked\Locksmith2' -PublishToPSGallery -PSGalleryAPIKey $env:PSGALLERY_KEY
+
+    .EXAMPLE
+    Invoke-LS2PostBuildPublish -ArtefactRoot '.\Artefacts\Unpacked\Locksmith2' -PublishToPSGallery -PSGalleryAPIPath 'C:\Secrets\psgallery.txt'
+
+    .OUTPUTS
+    None. Writes host/verbose messages only.
+
+    .NOTES
+    Pinned vendor versions are defined inside this function. Bump them here when updating deps.
+    #>
+    [CmdletBinding(SupportsShouldProcess)]
+    param(
+        [Parameter(Mandatory)]
+        [string]$ArtefactRoot,
+
+        [Parameter()]
+        [switch]$PublishToPSGallery,
+
+        [Parameter()]
+        [string]$PSGalleryAPIKey,
+
+        [Parameter()]
+        [string]$PSGalleryAPIPath
+    )
+
+    # ── Vendor dependencies ────────────────────────────────────────────────────
+    $modulesTarget = Join-Path $ArtefactRoot 'Modules'
+    New-Item -ItemType Directory -Path $modulesTarget -Force | Out-Null
+
+    $vendorVersions = [ordered] @{
+        PSWriteHTML = '1.41.0'
+        PSCertutil  = '0.0.3'
+    }
+
+    $nestedEntries = @()
+    foreach ($depName in $vendorVersions.Keys) {
+        $pinned = $vendorVersions[$depName]
+        $saveParams = @{
+            Name  = $depName
+            Path  = $modulesTarget
+            Force = $true
+        }
+        if ($pinned) { $saveParams['RequiredVersion'] = $pinned }
+        Write-Host "Saving $depName$(if ($pinned) { " $pinned" } else { ' (latest)' }) from PSGallery..."
+        Save-Module @saveParams
+
+        $ver = (Get-ChildItem (Join-Path $modulesTarget $depName) |
+            Sort-Object Name -Descending |
+            Select-Object -First 1).Name
+        Write-Host "Vendored $depName $ver."
+        $nestedEntries += "Modules\$depName\$ver\$depName.psm1"
+    }
+
+    $psd1 = Join-Path $ArtefactRoot 'Locksmith2.psd1'
+    Update-ModuleManifest -Path $psd1 -NestedModules $nestedEntries
+    Write-Host "Locksmith2.psd1 patched: NestedModules = $($nestedEntries -join ', ')"
+
+    # ── Publish from artefact path (not from PSModulePath) ────────────────────
+    if (-not $PublishToPSGallery) {
+        return
+    }
+
+    if ($PSGalleryAPIKey) {
+        $apiKey = $PSGalleryAPIKey
+    } elseif ($PSGalleryAPIPath) {
+        $apiKey = Get-Content -Path $PSGalleryAPIPath -ErrorAction Stop -Encoding UTF8 |
+            Select-Object -First 1
+    } else {
+        Write-Error '-PublishToPSGallery was specified but neither -PSGalleryAPIKey nor -PSGalleryAPIPath was provided.'
+        return
+    }
+
+    if ($PSCmdlet.ShouldProcess($ArtefactRoot, 'Publish-Module to PSGallery')) {
+        $publishParams = @{
+            Path        = $ArtefactRoot
+            NuGetApiKey = $apiKey
+            Repository  = 'PSGallery'
+            Force       = $true
+            ErrorAction = 'Stop'
+        }
+        Publish-Module @publishParams
+        Write-Host "Published Locksmith2 to PSGallery from $ArtefactRoot"
+    }
+}

--- a/Build/Invoke-LS2PostBuildPublish.ps1
+++ b/Build/Invoke-LS2PostBuildPublish.ps1
@@ -52,6 +52,9 @@ function Invoke-LS2PostBuildPublish {
     )
 
     # ── Vendor dependencies ────────────────────────────────────────────────────
+    Write-Host ''
+    Write-Host '[i] Vendoring dependencies into artefact' -ForegroundColor Cyan
+
     $modulesTarget = Join-Path $ArtefactRoot 'Modules'
     New-Item -ItemType Directory -Path $modulesTarget -Force | Out-Null
 
@@ -69,24 +72,28 @@ function Invoke-LS2PostBuildPublish {
             Force = $true
         }
         if ($pinned) { $saveParams['RequiredVersion'] = $pinned }
-        Write-Host "Saving $depName$(if ($pinned) { " $pinned" } else { ' (latest)' }) from PSGallery..."
+        $versionLabel = if ($pinned) { " $pinned" } else { ' (latest)' }
+        Write-Host "   [>] Saving $depName$versionLabel from PSGallery..." -ForegroundColor Yellow
         Save-Module @saveParams
 
         $ver = (Get-ChildItem (Join-Path $modulesTarget $depName) |
             Sort-Object Name -Descending |
             Select-Object -First 1).Name
-        Write-Host "Vendored $depName $ver."
+        Write-Host "   [+] Vendored $depName $ver" -ForegroundColor Green
         $nestedEntries += "Modules\$depName\$ver\$depName.psm1"
     }
 
     $psd1 = Join-Path $ArtefactRoot 'Locksmith2.psd1'
     Update-ModuleManifest -Path $psd1 -NestedModules $nestedEntries
-    Write-Host "Locksmith2.psd1 patched: NestedModules = $($nestedEntries -join ', ')"
+    Write-Host "[+] Locksmith2.psd1 patched - NestedModules = $($nestedEntries -join ', ')" -ForegroundColor Green
 
     # ── Publish from artefact path (not from PSModulePath) ────────────────────
     if (-not $PublishToPSGallery) {
         return
     }
+
+    Write-Host ''
+    Write-Host '[i] Publishing to PSGallery' -ForegroundColor Cyan
 
     if ($PSGalleryAPIKey) {
         $apiKey = $PSGalleryAPIKey
@@ -94,11 +101,13 @@ function Invoke-LS2PostBuildPublish {
         $apiKey = Get-Content -Path $PSGalleryAPIPath -ErrorAction Stop -Encoding UTF8 |
             Select-Object -First 1
     } else {
+        Write-Host '[x] -PublishToPSGallery specified but neither -PSGalleryAPIKey nor -PSGalleryAPIPath was provided.' -ForegroundColor Red
         Write-Error '-PublishToPSGallery was specified but neither -PSGalleryAPIKey nor -PSGalleryAPIPath was provided.'
         return
     }
 
     if ($PSCmdlet.ShouldProcess($ArtefactRoot, 'Publish-Module to PSGallery')) {
+        Write-Host "   [>] Calling Publish-Module -Path $ArtefactRoot" -ForegroundColor Yellow
         $publishParams = @{
             Path        = $ArtefactRoot
             NuGetApiKey = $apiKey
@@ -107,6 +116,6 @@ function Invoke-LS2PostBuildPublish {
             ErrorAction = 'Stop'
         }
         Publish-Module @publishParams
-        Write-Host "Published Locksmith2 to PSGallery from $ArtefactRoot"
+        Write-Host '[+] Published Locksmith2 to PSGallery successfully' -ForegroundColor Green
     }
 }

--- a/Locksmith2.psd1
+++ b/Locksmith2.psd1
@@ -8,11 +8,12 @@
     Description='An AD CS toolkit for AD Admins, Defensive Security Professionals, and Filthy Red Teamers'
     FunctionsToExport=@('*')
     GUID='e32f7d0d-2b10-4db2-b776-a193958e3d69'
-    ModuleVersion='2026.5.90937'
+    ModuleVersion='2026.5.100712'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{
             ExternalModuleDependencies=@('Microsoft.PowerShell.Utility',                'Microsoft.PowerShell.Archive',                'Microsoft.PowerShell.Management',                'Microsoft.PowerShell.Security',                'PowerShellGet',                'CimCmdlets')
+            Prerelease='pre'
             ProjectUri='https://github.com/jakehildreth/Locksmith2'
             RequireLicenseAcceptance=$false
             Tags=@('Locksmith',                'Locksmith2',                'ActiveDirectory',                'ADCS',                'CA',                'Certificate',                'CertificateAuthority',                'CertificateServices',                'PKI',                'X509',                'Windows')

--- a/Tests/Build/Build-Module.Tests.ps1
+++ b/Tests/Build/Build-Module.Tests.ps1
@@ -1,0 +1,140 @@
+BeforeAll {
+    . "$PSScriptRoot\..\..\Build\Invoke-LS2PostBuildPublish.ps1"
+
+    # Build the fake vendor tree that Get-ChildItem probes for version discovery.
+    # Save-Module is mocked so these dirs stand in for what it would have created.
+    function New-FakeArtefactRoot {
+        param([string]$Root)
+        $null = New-Item -ItemType Directory -Path $Root -Force
+        foreach ($pair in @('PSWriteHTML\1.41.0', 'PSCertutil\0.0.3')) {
+            $null = New-Item -ItemType Directory -Path (Join-Path $Root "Modules\$pair") -Force
+        }
+    }
+}
+
+Describe 'Invoke-LS2PostBuildPublish' {
+
+    Context 'When PublishToPSGallery is not requested' {
+        BeforeAll {
+            $artefactRoot = 'TestDrive:\root-no-publish'
+            New-FakeArtefactRoot -Root $artefactRoot
+            Mock Save-Module {}
+            Mock Update-ModuleManifest {}
+            Mock Publish-Module {}
+        }
+
+        It 'Should not call Publish-Module' {
+            Invoke-LS2PostBuildPublish -ArtefactRoot $artefactRoot -PublishToPSGallery:$false -PSGalleryAPIKey 'dummy'
+            Should -Invoke Publish-Module -Exactly 0
+        }
+
+        It 'Should still vendor dependencies' {
+            Mock Save-Module {} -Verifiable
+            Invoke-LS2PostBuildPublish -ArtefactRoot $artefactRoot -PublishToPSGallery:$false -PSGalleryAPIKey 'dummy'
+            Should -InvokeVerifiable
+        }
+    }
+
+    Context 'When PublishToPSGallery is requested with an API key' {
+        BeforeAll {
+            $artefactRoot = 'TestDrive:\root-with-key'
+            New-FakeArtefactRoot -Root $artefactRoot
+            Mock Save-Module {}
+            Mock Update-ModuleManifest {}
+            Mock Publish-Module {}
+        }
+
+        It 'Should call Publish-Module exactly once' {
+            Invoke-LS2PostBuildPublish -ArtefactRoot $artefactRoot -PublishToPSGallery -PSGalleryAPIKey 'fake-key'
+            Should -Invoke Publish-Module -Exactly 1
+        }
+
+        It 'Should pass -Path pointing at the artefact root' {
+            Mock Publish-Module {}
+            Invoke-LS2PostBuildPublish -ArtefactRoot $artefactRoot -PublishToPSGallery -PSGalleryAPIKey 'fake-key'
+            Should -Invoke Publish-Module -ParameterFilter { $Path -eq $artefactRoot } -Exactly 1
+        }
+
+        It 'Should pass the API key to Publish-Module' {
+            Mock Publish-Module {}
+            Invoke-LS2PostBuildPublish -ArtefactRoot $artefactRoot -PublishToPSGallery -PSGalleryAPIKey 'fake-key'
+            Should -Invoke Publish-Module -ParameterFilter { $NuGetApiKey -eq 'fake-key' } -Exactly 1
+        }
+
+        It 'Should NOT use -Name when publishing' {
+            Mock Publish-Module {}
+            Invoke-LS2PostBuildPublish -ArtefactRoot $artefactRoot -PublishToPSGallery -PSGalleryAPIKey 'fake-key'
+            Should -Invoke Publish-Module -ParameterFilter { -not $PSBoundParameters.ContainsKey('Name') } -Exactly 1
+        }
+    }
+
+    Context 'When PublishToPSGallery is requested but no API key or path provided' {
+        BeforeAll {
+            $artefactRoot = 'TestDrive:\root-no-key'
+            New-FakeArtefactRoot -Root $artefactRoot
+            Mock Save-Module {}
+            Mock Update-ModuleManifest {}
+            Mock Publish-Module {}
+            Mock Write-Error {}
+        }
+
+        It 'Should not call Publish-Module' {
+            Invoke-LS2PostBuildPublish -ArtefactRoot $artefactRoot -PublishToPSGallery
+            Should -Invoke Publish-Module -Exactly 0
+        }
+
+        It 'Should write an error' {
+            Mock Write-Error {} -Verifiable
+            Invoke-LS2PostBuildPublish -ArtefactRoot $artefactRoot -PublishToPSGallery
+            Should -InvokeVerifiable
+        }
+    }
+
+    Context 'When PublishToPSGallery is requested with an API file path' {
+        BeforeAll {
+            $artefactRoot = 'TestDrive:\root-file-key'
+            New-FakeArtefactRoot -Root $artefactRoot
+            Mock Save-Module {}
+            Mock Update-ModuleManifest {}
+            $fakeKeyFile = 'TestDrive:\api.txt'
+            Set-Content -Path $fakeKeyFile -Value 'file-key'
+        }
+
+        It 'Should read the key from the file and pass it to Publish-Module' {
+            Mock Publish-Module {}
+            Invoke-LS2PostBuildPublish -ArtefactRoot $artefactRoot -PublishToPSGallery -PSGalleryAPIPath $fakeKeyFile
+            Should -Invoke Publish-Module -ParameterFilter { $NuGetApiKey -eq 'file-key' } -Exactly 1
+        }
+    }
+
+    Context 'Vendoring always runs' {
+        BeforeAll {
+            $artefactRoot = 'TestDrive:\root-vendor'
+            New-FakeArtefactRoot -Root $artefactRoot
+            Mock Update-ModuleManifest {}
+            Mock Publish-Module {}
+        }
+
+        It 'Should call Save-Module for PSWriteHTML' {
+            Mock Save-Module {} -ParameterFilter { $Name -eq 'PSWriteHTML' } -Verifiable
+            Mock Save-Module {} -ParameterFilter { $Name -eq 'PSCertutil' }
+            Invoke-LS2PostBuildPublish -ArtefactRoot $artefactRoot -PublishToPSGallery:$false
+            Should -InvokeVerifiable
+        }
+
+        It 'Should call Save-Module for PSCertutil' {
+            Mock Save-Module {} -ParameterFilter { $Name -eq 'PSWriteHTML' }
+            Mock Save-Module {} -ParameterFilter { $Name -eq 'PSCertutil' } -Verifiable
+            Invoke-LS2PostBuildPublish -ArtefactRoot $artefactRoot -PublishToPSGallery:$false
+            Should -InvokeVerifiable
+        }
+
+        It 'Should call Update-ModuleManifest to patch NestedModules' {
+            Mock Save-Module {}
+            Mock Update-ModuleManifest {} -Verifiable
+            Invoke-LS2PostBuildPublish -ArtefactRoot $artefactRoot -PublishToPSGallery:$false
+            Should -InvokeVerifiable
+        }
+    }
+}
+


### PR DESCRIPTION
## Problem

When publishing via `New-ConfigurationPublish` inside the `Build-Module {}` scriptblock, PSPublishModule calls `Publish-Module -Name Locksmith2` which resolves the module from `$PSModulePath`. That copy is written *before* the post-build vendoring step, so `PSWriteHTML` and `PSCertutil` are never included in what gets uploaded to PSGallery.

## Solution

- Removed `New-ConfigurationPublish` from the `Build-Module {}` scriptblock entirely
- Extracted all post-build logic into `Build/Invoke-LS2PostBuildPublish.ps1`, a proper advanced function with `SupportsShouldProcess` and comment-based help
- `Build-Module.ps1` now dot-sources and calls `Invoke-LS2PostBuildPublish` *after* `Build-Module {}` completes, so `Publish-Module -Path $artefactRoot` sees the fully vendored `Modules\` tree
- Added colored `[i]`/`[>]`/`[+]`/`[x]` output matching PSPublishModule's style

## Tests

Added `Tests/Build/Build-Module.Tests.ps1` with 12 unit tests covering:
- vendoring always runs regardless of publish flag
- `Publish-Module` is not called when `-PublishToPSGallery` is absent
- `-Path` (not `-Name`) is passed to `Publish-Module`
- API key passed correctly via direct string or file path
- error written when publish requested but no key provided

## CI Impact

No changes to `publish.yml` required — the workflow already passes `$env:PSGALLERY_API_KEY` via `-PSGalleryAPIKey` and `Build-Module.ps1` forwards it through.