### PR TITLE
fix(dashboard): embed logo as base64 data URI for portable HTML output

### DIFF
--- a/Locksmith2.psd1
+++ b/Locksmith2.psd1
@@ -8,7 +8,7 @@
     Description='An AD CS toolkit for AD Admins, Defensive Security Professionals, and Filthy Red Teamers'
     FunctionsToExport=@('*')
     GUID='e32f7d0d-2b10-4db2-b776-a193958e3d69'
-    ModuleVersion='2026.5.121255'
+    ModuleVersion='2026.5.121323'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{

--- a/Public/New-LS2Dashboard.ps1
+++ b/Public/New-LS2Dashboard.ps1
@@ -162,14 +162,19 @@ function New-LS2Dashboard {
     $generatedAt  = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
     $scanUser     = if ($script:Credential) { $script:Credential.UserName } else { [System.Security.Principal.WindowsIdentity]::GetCurrent().Name }
     $scanComputer = "$env:USERDOMAIN\$env:COMPUTERNAME"
-    # Resolve logo — try module base first, then walk up for source-tree runs
-    $logoPath = $null
+    # Resolve logo and encode as base64 data URI for self-contained HTML
+    $logoSource = $null
     $moduleBase = (Get-Module -Name Locksmith2 -ErrorAction SilentlyContinue).ModuleBase
     foreach ($candidate in @(
         (Join-Path $moduleBase 'Images\Locksmith2.png'),
         (Join-Path $moduleBase '..\..\..\Images\Locksmith2.png')
     )) {
-        if (Test-Path $candidate) { $logoPath = (Resolve-Path $candidate).Path; break }
+        if (Test-Path $candidate) {
+            $logoBytes  = [System.IO.File]::ReadAllBytes((Resolve-Path $candidate).Path)
+            $logoBase64 = [System.Convert]::ToBase64String($logoBytes)
+            $logoSource = "data:image/png;base64,$logoBase64"
+            break
+        }
     }
 
     # Conditional formatting shared by all issue tables
@@ -215,8 +220,8 @@ function New-LS2Dashboard {
         # container and does not create a tab-content slot (unlike New-HTMLSection/Panel at this level).
         New-HTMLHeader {
             Add-HTMLStyle -Content 'header { text-align: center; padding: 12px 0; } header img { max-width: 50%; height: auto; display: inline-block; }'
-            if ($logoPath) {
-                New-HTMLImage -Source $logoPath -Width '50%' -DisableCache -AlternativeText 'Locksmith 2'
+            if ($logoSource) {
+                New-HTMLImage -Source $logoSource -Width '50%' -AlternativeText 'Locksmith 2'
             }
             New-HTMLText -Text "Forest: $forestName  |  User: $scanUser  |  Computer: $scanComputer  |  Generated: $generatedAt" -FontSize 12 -Color '#555' -Alignment center
         }


### PR DESCRIPTION
## Summary

The dashboard HTML was embedding the logo as an absolute local filesystem path (`src="C:\Users\...\Images\Locksmith2.png"`), making the output non-portable — the image would not render on any machine other than the one that generated the report.

## Changes

- Resolve logo path candidates as before (module base → source-tree fallback)
- On first match, read the PNG bytes with `[System.IO.File]::ReadAllBytes` and encode via `[System.Convert]::ToBase64String`
- Pass the resulting `data:image/png;base64,...` URI as the image source instead of the file path
- Removed `-DisableCache` from `New-HTMLImage` (not applicable to data URIs)
- Bumped `ModuleVersion` to `2026.5.121323`

## Result

Dashboard HTML files are now fully self-contained — the logo renders correctly when opened on any machine, sent via email, or archived.

## Testing

- Built module and ran `Invoke-Locksmith2; New-LS2Dashboard`
- Confirmed generated HTML contains `src="data:image/png;base64,..."` instead of a filesystem path