### PR TITLE
fix(build): correct stale CalVer comment format string

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -1,5 +1,5 @@
 ﻿param (
-    # A CalVer string if you need to manually override the default yyyy.M.d version string.
+    # A CalVer string if you need to manually override the default yyyy.M.dHHmm version string.
     [string]$CalVer,
     # A prerelease tag to append to the module version (e.g., 'alpha', 'beta', 'rc1').
     [string]$Prerelease,


### PR DESCRIPTION
The `$CalVer` parameter comment incorrectly documented the format as `yyyy.M.d`
when the actual format used throughout the build script is `yyyy.M.dHHmm`.

## Changes

- **Build/Build-Module.ps1**: updated `$CalVer` param comment from `yyyy.M.d`
  to `yyyy.M.dHHmm` to match the `Get-Date -Format 'yyyy.M.dHHmm'` call used
  to generate the default module version