### PR TITLE
Update Invoke-Locksmith2.ps1

### DIFF
--- a/Public/Invoke-Locksmith2.ps1
+++ b/Public/Invoke-Locksmith2.ps1
@@ -127,7 +127,8 @@ function Invoke-Locksmith2 {
         [switch]$SkipPowerShellCheck,
         [switch]$SkipForestCheck,
         [switch]$ExpandGroups,
-        [switch]$Rescan
+        [switch]$Rescan,
+        [switch]$Force
     )
 
     #requires -Version 5.1
@@ -172,7 +173,12 @@ function Invoke-Locksmith2 {
         Write-Host "  Computer : $($env:USERDOMAIN.ToUpper())\$($env:COMPUTERNAME.ToUpper())"
         Write-Host "  Method   : $($ctx.Method)"
         Write-Host ''
-        $confirm = Read-Choice -Question 'Proceed with scan?' -Options @('y', 'n') -Default 'y'
+        if ($Force) {
+            $confirm = 'y'
+        }
+        else {
+            $confirm = Read-Choice -Question 'Proceed with scan?' -Options @('y', 'n') -Default 'y'
+        }
         if ($confirm -ne 'y') {
             Write-Host 'Scan cancelled.' -ForegroundColor Yellow
             return
@@ -221,7 +227,8 @@ function Invoke-Locksmith2 {
     if ($PSBoundParameters.ContainsKey('Mode')) {
         # Display issues in console using specified mode
         Show-IssueReport -Issues $allIssues -Mode $Mode
-    } else {
+    }
+    else {
         # Return LS2Issue objects to pipeline
         $allIssues
     }

--- a/Public/Invoke-Locksmith2.ps1
+++ b/Public/Invoke-Locksmith2.ps1
@@ -173,10 +173,9 @@ function Invoke-Locksmith2 {
         Write-Host "  Computer : $($env:USERDOMAIN.ToUpper())\$($env:COMPUTERNAME.ToUpper())"
         Write-Host "  Method   : $($ctx.Method)"
         Write-Host ''
-        if ($Force) {
+        if ($Force -or (`[System.Environment]::UserInteractive`) ) {
             $confirm = 'y'
-        }
-        else {
+        } else {
             $confirm = Read-Choice -Question 'Proceed with scan?' -Options @('y', 'n') -Default 'y'
         }
         if ($confirm -ne 'y') {
@@ -227,8 +226,7 @@ function Invoke-Locksmith2 {
     if ($PSBoundParameters.ContainsKey('Mode')) {
         # Display issues in console using specified mode
         Show-IssueReport -Issues $allIssues -Mode $Mode
-    }
-    else {
+    } else {
         # Return LS2Issue objects to pipeline
         $allIssues
     }


### PR DESCRIPTION
## Problem
When running Invoke-Locksmith2 in automated/unattended scenarios (scheduled tasks, 
CI pipelines), the interactive "Proceed with scan? [Y/n]" prompt blocks execution.

## Solution
Added a `-Force` switch parameter that bypasses the confirmation prompt, 
consistent with PowerShell conventions for non-interactive use.

## Usage
```powershell
Invoke-Locksmith2 -Mode 0 -Force
```

## Testing
- Verified prompt is skipped when `-Force` is used
- Existing interactive behavior unchanged when `-Force` is omitted