### PR TITLE
docs(readme): refresh title and quick start for clarity

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,5 +1,6 @@
 ![The Locksmith 2 logo features the word "locksmith" followed by the number "2" in a bold, blocky pixelated font. The design uses a gradient color scheme transitioning from light lavender on the left through pink tones to coral/orange on the right, set against a dark purple background with a rectangular border. The retro-digital aesthetic gives the logo a modern yet approachable feel, suggesting a tool that makes security management accessible and straightforward. The "2" indicates this is the second version of the Locksmith tool.](Images/Locksmith2.png)
-# Find and Fix Active Directory Certificate Services (AD CS) Security Misconfigurations
+
+# An AD CS toolkit for Active Directory Admins, Defensive Security Professionals, and Filthy Red Teamers
 
 [![PowerShell Gallery](https://img.shields.io/powershellgallery/v/Locksmith2.svg)](https://www.powershellgallery.com/packages/Locksmith2)
 [![PowerShell](https://img.shields.io/badge/PowerShell-5.1+-blue.svg)](https://github.com/PowerShell/PowerShell)[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/jakehildreth/Locksmith2)
@@ -49,24 +50,15 @@ Import-Module .\Locksmith2.psd1
 
 ## Quick Start
 
+### Start in Interactive mode
+
 ```powershell
-# Interactive mode - prompts for forest and credentials
 Invoke-Locksmith2
+```
 
-# Specify credentials
-$cred = Get-Credential
-Invoke-Locksmith2 -Forest 'contoso.com' -Credential $cred
-
-# Targeted scanning for specific techniques
-Find-LS2VulnerableTemplate -Technique ESC1
-Find-LS2VulnerableCA -Technique ESC6
-
-# Analyze which principals have the most exploitable paths
-Find-LS2RiskyPrincipal -Top 10
-
-# Inspect results
-$stores = Get-LS2Stores
-$stores.IssueStore['ESC1']
+### Generate HTML Dashboard
+```powershell
+New-LS2Dashboard
 ```
 
 ## Supported ESC Techniques


### PR DESCRIPTION
## Summary
Refresh the README title and Quick Start section to better match the project's current scope and reduce cognitive load for new users.

## Changes
- `README.MD`
  - Updated title from AD CS misconfiguration focus to broader AD CS toolkit positioning
  - Simplified Quick Start to two core examples: interactive mode (`Invoke-Locksmith2`) and HTML dashboard generation (`New-LS2Dashboard`)
  - Removed verbose examples for credentials, targeted technique scans, risky principals, and store inspection

## Why
The previous Quick Start was dense and assumed familiarity with Locksmith 2's cmdlet surface. This version surfaces the two most common entry points and lets the rest of the README carry the detail.

## Verification
- [x] Rendered README locally
- [x] No functional code changes