### PR TITLE
feat(risk-rating): implement per-issue risk scoring engine

### DIFF
--- a/Classes/LS2Issue.ps1
+++ b/Classes/LS2Issue.ps1
@@ -32,6 +32,15 @@ class LS2Issue {
     [string]$Issue                  # Description of the vulnerability
     [string]$Fix                    # PowerShell script to remediate
     [string]$Revert                 # PowerShell script to undo remediation
+
+    # Risk rating (populated by Set-LS2RiskRating)
+    [Nullable[int]]$RiskValue       # Numeric risk score
+    [string]$RiskName               # Informational / Low / Medium / High / Critical
+    [string[]]$RiskScoring          # Audit trail of each modifier applied
+
+    # ESC8 endpoint metadata (populated by Find-LS2VulnerableCA)
+    [string]$EndpointURL            # Full URL of the ESC8 endpoint
+    [string]$EndpointAttackVector   # HTTP / HTTPS-NTLM / HTTPS-Kerberos
     
     # Constructor for creating issues from hashtable
     LS2Issue([hashtable]$Properties) {
@@ -65,6 +74,15 @@ class LS2Issue {
         $this.Issue = $Properties.Issue
         $this.Fix = $Properties.Fix
         $this.Revert = $Properties.Revert
+
+        # Risk rating
+        $this.RiskValue = $Properties.RiskValue
+        $this.RiskName = $Properties.RiskName
+        $this.RiskScoring = $Properties.RiskScoring
+
+        # ESC8 endpoint metadata
+        $this.EndpointURL = $Properties.EndpointURL
+        $this.EndpointAttackVector = $Properties.EndpointAttackVector
     }
     
     # Method to get a friendly identifier for the issue

--- a/Docs/ADR/0003-escscoring-metadata-split-from-data-block.md
+++ b/Docs/ADR/0003-escscoring-metadata-split-from-data-block.md
@@ -1,0 +1,65 @@
+# ADR-0003: Separate ESC Scoring Metadata from the ESCDefinitions data{} Block
+
+## Status
+
+Accepted
+
+## Context
+
+`Private/Data/ESCDefinitions.ps1` defines configuration for all 19 ESC vulnerability
+techniques using a PowerShell `data { }` statement. The `data` statement provides a
+constrained execution environment — it restricts the expression types allowed inside
+it to prevent accidental side effects (no function calls, no complex expressions, only
+literals, `if`/`elseif`/`else`, and a small whitelist of `ConvertFrom-StringData` calls).
+
+When implementing the risk-rating engine (feat/risk-rating), each technique entry
+required new scoring keys:
+
+- `BaseScore` (int)
+- `TechniqueBonus` (int)
+- `ApplyEnabledModifier` (bool)
+- `ApplyPrincipalRisk` (bool)
+- `ApplyObjectClassBonus` (bool)
+- `ObjectClassBonuses` (hashtable)
+- `NtAuthBonus` (int)
+- `EndpointBonuses` (hashtable)
+- `CrossESCModifiers` (array of hashtables)
+
+The deeply nested `CrossESCModifiers` structure requires arrays of hashtables with
+nested arrays (e.g., `RequiredTechniquePatterns = @('ESC5a', 'ESC5o')`). While
+these values are technically literals, the `data {}` block's constrained mode is
+strict enough that adding this depth of nesting inline created fragility and
+maintenance risk as the block grew.
+
+## Decision
+
+Define scoring metadata in a separate `$script:ESCScoringMetadata` hashtable (a plain
+`@{ }` expression outside the `data {}` block), keyed by technique name (e.g.,
+`'ESC1'`, `'ESC5a'`). After the `data {}` block populates `$script:ESCDefinitions`,
+a merge loop copies all scoring keys from `$script:ESCScoringMetadata` into the
+corresponding entries in `$script:ESCDefinitions`.
+
+All callers see a unified `$script:ESCDefinitions['ESC1']` entry that contains both
+detection/remediation keys (from `data {}`) and scoring keys (from the merge). The
+split is a load-time implementation detail — it is invisible to the rest of the module.
+
+The alternative — collapsing `data {}` into a plain `@{ }` — was explicitly rejected.
+The `data {}` block provides a meaningful constraint that protects the detection and
+remediation content from inadvertent side effects. Removing it to accommodate scoring
+keys would erode that safety net for the wrong reason.
+
+## Consequences
+
+[+] The `data {}` block retains its constrained-mode guarantees for all
+    detection/remediation content, reducing the risk of accidental side effects.
+[+] Scoring metadata is grouped together in one place, making it easy to review and
+    audit all 19 technique scores as a table.
+[+] The merge loop is the only coupling between the two structures; adding a new
+    scoring key requires updating `$script:ESCScoringMetadata` entries only.
+[!] A developer unfamiliar with the pattern may be confused by `$script:ESCDefinitions`
+    containing keys not visible inside the `data {}` block. The merge loop and this
+    ADR serve as the canonical explanation.
+[!] Technique names must be consistent between the `data {}` block keys and the
+    `$script:ESCScoringMetadata` keys. A typo in one will silently leave the scoring
+    keys absent for that technique. Tests in `Tests/Private/Data/ESCDefinitions.Tests.ps1`
+    validate that every known technique has all required scoring keys present.

--- a/Locksmith2.psd1
+++ b/Locksmith2.psd1
@@ -8,7 +8,7 @@
     Description='An AD CS toolkit for AD Admins, Defensive Security Professionals, and Filthy Red Teamers'
     FunctionsToExport=@('*')
     GUID='e32f7d0d-2b10-4db2-b776-a193958e3d69'
-    ModuleVersion='2026.5.131651'
+    ModuleVersion='2026.5.151534'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{

--- a/Private/Data/ESCDefinitions.ps1
+++ b/Private/Data/ESCDefinitions.ps1
@@ -821,3 +821,391 @@ $script:ESCDefinitions = data {
         }
     }
 }
+
+# ============================================================================
+# Scoring metadata for Set-LS2RiskRating
+# Defined outside data{} because data{} only allows literals and restricted syntax.
+# Keys are merged into $script:ESCDefinitions at load time.
+# ============================================================================
+$script:ESCScoringMetadata = @{
+    ESC1   = @{
+        BaseScore             = 0
+        TechniqueBonus        = 1
+        ApplyEnabledModifier  = $true
+        ApplyPrincipalRisk    = $true
+        ApplyObjectClassBonus = $false
+        ObjectClassBonuses    = @{}
+        NtAuthBonus           = 0
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @(
+            @{
+                RequiredTechniquePatterns = @('ESC5a', 'ESC5o')
+                Bonus                    = 0
+                BonusFromPrincipalRisk   = $true
+                BonusCap                 = 2
+                OnlyWhenDisabled         = $true
+                RequiredObjectClass      = 'pKIEnrollmentService'
+                OnlyEnabledMatches       = $false
+            }
+        )
+    }
+    ESC2   = @{
+        BaseScore             = 0
+        TechniqueBonus        = 0
+        ApplyEnabledModifier  = $true
+        ApplyPrincipalRisk    = $true
+        ApplyObjectClassBonus = $false
+        ObjectClassBonuses    = @{}
+        NtAuthBonus           = 0
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @(
+            @{
+                RequiredTechniquePatterns = @('ESC5a', 'ESC5o')
+                Bonus                    = 0
+                BonusFromPrincipalRisk   = $true
+                BonusCap                 = 2
+                OnlyWhenDisabled         = $true
+                RequiredObjectClass      = 'pKIEnrollmentService'
+                OnlyEnabledMatches       = $false
+            }
+            @{
+                RequiredTechniquePatterns = @('ESC15')
+                Bonus                    = 0
+                BonusFromPrincipalRisk   = $true
+                BonusCap                 = 2
+                OnlyWhenDisabled         = $false
+                RequiredObjectClass      = ''
+                OnlyEnabledMatches       = $true
+            }
+        )
+    }
+    ESC3c1 = @{
+        BaseScore             = 0
+        TechniqueBonus        = 0
+        ApplyEnabledModifier  = $true
+        ApplyPrincipalRisk    = $true
+        ApplyObjectClassBonus = $false
+        ObjectClassBonuses    = @{}
+        NtAuthBonus           = 0
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @(
+            @{
+                RequiredTechniquePatterns = @('ESC5a', 'ESC5o')
+                Bonus                    = 0
+                BonusFromPrincipalRisk   = $true
+                BonusCap                 = 2
+                OnlyWhenDisabled         = $true
+                RequiredObjectClass      = 'pKIEnrollmentService'
+                OnlyEnabledMatches       = $false
+            }
+            @{
+                RequiredTechniquePatterns = @('ESC15')
+                Bonus                    = 0
+                BonusFromPrincipalRisk   = $true
+                BonusCap                 = 2
+                OnlyWhenDisabled         = $false
+                RequiredObjectClass      = ''
+                OnlyEnabledMatches       = $true
+            }
+        )
+    }
+    ESC3c2 = @{
+        BaseScore             = 0
+        TechniqueBonus        = 0
+        ApplyEnabledModifier  = $true
+        ApplyPrincipalRisk    = $true
+        ApplyObjectClassBonus = $false
+        ObjectClassBonuses    = @{}
+        NtAuthBonus           = 0
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @(
+            @{
+                RequiredTechniquePatterns = @('ESC5a', 'ESC5o')
+                Bonus                    = 0
+                BonusFromPrincipalRisk   = $true
+                BonusCap                 = 2
+                OnlyWhenDisabled         = $true
+                RequiredObjectClass      = 'pKIEnrollmentService'
+                OnlyEnabledMatches       = $false
+            }
+            @{
+                RequiredTechniquePatterns = @('ESC3c1', 'ESC2')
+                Bonus                    = 0
+                BonusFromPrincipalRisk   = $true
+                BonusCap                 = 2
+                OnlyWhenDisabled         = $false
+                RequiredObjectClass      = ''
+                OnlyEnabledMatches       = $true
+            }
+        )
+    }
+    ESC4a  = @{
+        BaseScore             = 0
+        TechniqueBonus        = 1
+        ApplyEnabledModifier  = $true
+        ApplyPrincipalRisk    = $true
+        ApplyObjectClassBonus = $false
+        ObjectClassBonuses    = @{}
+        NtAuthBonus           = 0
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @(
+            @{
+                RequiredTechniquePatterns = @('ESC5a', 'ESC5o')
+                Bonus                    = 0
+                BonusFromPrincipalRisk   = $true
+                BonusCap                 = 2
+                OnlyWhenDisabled         = $true
+                RequiredObjectClass      = 'pKIEnrollmentService'
+                OnlyEnabledMatches       = $false
+            }
+        )
+    }
+    ESC4o  = @{
+        BaseScore             = 0
+        TechniqueBonus        = 1
+        ApplyEnabledModifier  = $true
+        ApplyPrincipalRisk    = $false
+        ApplyObjectClassBonus = $false
+        ObjectClassBonuses    = @{}
+        NtAuthBonus           = 0
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @(
+            @{
+                RequiredTechniquePatterns = @('ESC5a', 'ESC5o')
+                Bonus                    = 0
+                BonusFromPrincipalRisk   = $true
+                BonusCap                 = 2
+                OnlyWhenDisabled         = $true
+                RequiredObjectClass      = 'pKIEnrollmentService'
+                OnlyEnabledMatches       = $false
+            }
+        )
+    }
+    ESC5a  = @{
+        BaseScore             = 0
+        TechniqueBonus        = 0
+        ApplyEnabledModifier  = $false
+        ApplyPrincipalRisk    = $true
+        ApplyObjectClassBonus = $true
+        ObjectClassBonuses    = @{
+            'certificationAuthority' = 2
+            'pKIEnrollmentService'   = 2
+            'computer'               = 2
+            'msPKI-Enterprise-Oid'   = 1
+            'container'              = 1
+        }
+        NtAuthBonus           = 2
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @()
+    }
+    ESC5o  = @{
+        BaseScore             = 0
+        TechniqueBonus        = 0
+        ApplyEnabledModifier  = $false
+        ApplyPrincipalRisk    = $false
+        ApplyObjectClassBonus = $true
+        ObjectClassBonuses    = @{
+            'certificationAuthority' = 2
+            'pKIEnrollmentService'   = 2
+            'computer'               = 2
+            'msPKI-Enterprise-Oid'   = 1
+            'container'              = 1
+        }
+        NtAuthBonus           = 2
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @()
+    }
+    ESC6   = @{
+        BaseScore             = 3
+        TechniqueBonus        = 0
+        ApplyEnabledModifier  = $false
+        ApplyPrincipalRisk    = $false
+        ApplyObjectClassBonus = $false
+        ObjectClassBonuses    = @{}
+        NtAuthBonus           = 0
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @(
+            @{
+                RequiredTechniquePatterns = @('ESC9', 'ESC16')
+                Bonus                    = 2
+                BonusFromPrincipalRisk   = $false
+                BonusCap                 = 2
+                OnlyWhenDisabled         = $false
+                RequiredObjectClass      = ''
+                OnlyEnabledMatches       = $false
+            }
+        )
+    }
+    ESC7a  = @{
+        BaseScore             = 3
+        TechniqueBonus        = 0
+        ApplyEnabledModifier  = $false
+        ApplyPrincipalRisk    = $true
+        ApplyObjectClassBonus = $false
+        ObjectClassBonuses    = @{}
+        NtAuthBonus           = 0
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @()
+    }
+    ESC7m  = @{
+        BaseScore             = 3
+        TechniqueBonus        = 0
+        ApplyEnabledModifier  = $false
+        ApplyPrincipalRisk    = $true
+        ApplyObjectClassBonus = $false
+        ObjectClassBonuses    = @{}
+        NtAuthBonus           = 0
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @()
+    }
+    ESC8   = @{
+        BaseScore             = 3
+        TechniqueBonus        = 0
+        ApplyEnabledModifier  = $false
+        ApplyPrincipalRisk    = $false
+        ApplyObjectClassBonus = $false
+        ObjectClassBonuses    = @{}
+        NtAuthBonus           = 0
+        EndpointBonuses       = @{
+            'HTTP'           = 2
+            'HTTPS-NTLM'     = 2
+            'HTTPS-Kerberos' = 1
+        }
+        CrossESCModifiers     = @()
+    }
+    ESC9   = @{
+        BaseScore             = 0
+        TechniqueBonus        = 0
+        ApplyEnabledModifier  = $true
+        ApplyPrincipalRisk    = $true
+        ApplyObjectClassBonus = $false
+        ObjectClassBonuses    = @{}
+        NtAuthBonus           = 0
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @(
+            @{
+                RequiredTechniquePatterns = @('ESC5a', 'ESC5o')
+                Bonus                    = 0
+                BonusFromPrincipalRisk   = $true
+                BonusCap                 = 2
+                OnlyWhenDisabled         = $true
+                RequiredObjectClass      = 'pKIEnrollmentService'
+                OnlyEnabledMatches       = $false
+            }
+            @{
+                RequiredTechniquePatterns = @('ESC6')
+                Bonus                    = 2
+                BonusFromPrincipalRisk   = $false
+                BonusCap                 = 2
+                OnlyWhenDisabled         = $false
+                RequiredObjectClass      = ''
+                OnlyEnabledMatches       = $false
+            }
+        )
+    }
+    ESC11  = @{
+        BaseScore             = 3
+        TechniqueBonus        = 0
+        ApplyEnabledModifier  = $false
+        ApplyPrincipalRisk    = $false
+        ApplyObjectClassBonus = $false
+        ObjectClassBonuses    = @{}
+        NtAuthBonus           = 0
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @()
+    }
+    ESC13  = @{
+        BaseScore             = 0
+        TechniqueBonus        = 0
+        ApplyEnabledModifier  = $true
+        ApplyPrincipalRisk    = $true
+        ApplyObjectClassBonus = $false
+        ObjectClassBonuses    = @{}
+        NtAuthBonus           = 0
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @(
+            @{
+                RequiredTechniquePatterns = @('ESC5a', 'ESC5o')
+                Bonus                    = 0
+                BonusFromPrincipalRisk   = $true
+                BonusCap                 = 2
+                OnlyWhenDisabled         = $true
+                RequiredObjectClass      = 'pKIEnrollmentService'
+                OnlyEnabledMatches       = $false
+            }
+        )
+    }
+    ESC15  = @{
+        BaseScore             = 0
+        TechniqueBonus        = 0
+        ApplyEnabledModifier  = $true
+        ApplyPrincipalRisk    = $true
+        ApplyObjectClassBonus = $false
+        ObjectClassBonuses    = @{}
+        NtAuthBonus           = 0
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @(
+            @{
+                RequiredTechniquePatterns = @('ESC5a', 'ESC5o')
+                Bonus                    = 0
+                BonusFromPrincipalRisk   = $true
+                BonusCap                 = 2
+                OnlyWhenDisabled         = $true
+                RequiredObjectClass      = 'pKIEnrollmentService'
+                OnlyEnabledMatches       = $false
+            }
+        )
+    }
+    ESC16  = @{
+        BaseScore             = 3
+        TechniqueBonus        = 0
+        ApplyEnabledModifier  = $false
+        ApplyPrincipalRisk    = $false
+        ApplyObjectClassBonus = $false
+        ObjectClassBonuses    = @{}
+        NtAuthBonus           = 0
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @(
+            @{
+                RequiredTechniquePatterns = @('ESC6')
+                Bonus                    = 2
+                BonusFromPrincipalRisk   = $false
+                BonusCap                 = 2
+                OnlyWhenDisabled         = $false
+                RequiredObjectClass      = ''
+                OnlyEnabledMatches       = $false
+            }
+        )
+    }
+    SchemaV1 = @{
+        BaseScore             = 1
+        TechniqueBonus        = 0
+        ApplyEnabledModifier  = $true
+        ApplyPrincipalRisk    = $false
+        ApplyObjectClassBonus = $false
+        ObjectClassBonuses    = @{}
+        NtAuthBonus           = 0
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @()
+    }
+    Auditing = @{
+        BaseScore             = 3
+        TechniqueBonus        = 0
+        ApplyEnabledModifier  = $false
+        ApplyPrincipalRisk    = $false
+        ApplyObjectClassBonus = $false
+        ObjectClassBonuses    = @{}
+        NtAuthBonus           = 0
+        EndpointBonuses       = @{}
+        CrossESCModifiers     = @()
+    }
+}
+
+# Merge scoring metadata into ESCDefinitions
+foreach ($technique in $script:ESCScoringMetadata.Keys) {
+    if ($script:ESCDefinitions.ContainsKey($technique)) {
+        foreach ($scoringKey in $script:ESCScoringMetadata[$technique].Keys) {
+            $script:ESCDefinitions[$technique][$scoringKey] = $script:ESCScoringMetadata[$technique][$scoringKey]
+        }
+    }
+}

--- a/Private/Set/Get-PrincipalRiskBonus.ps1
+++ b/Private/Set/Get-PrincipalRiskBonus.ps1
@@ -1,0 +1,84 @@
+function Get-PrincipalRiskBonus {
+    <#
+    .SYNOPSIS
+        Computes the principal risk bonus score for a given SID and class.
+    .DESCRIPTION
+        Additive evaluation — modifiers accumulate independently:
+          1. SafePrincipal match            -> Score=0, Labels=@()  (early return)
+          2. DangerousPrincipal match       -> Score=3, Labels=['UnsafePrincipal: +1', 'DangerousPrincipal: +2']
+             (group modifier never applies to dangerous principals)
+          3. UnsafePrincipal (not safe, not dangerous, class = 'group') -> Score=2, Labels=['UnsafePrincipal: +1', 'UnsafeGroup: +1']
+          4. UnsafePrincipal (not safe, not dangerous, non-group)       -> Score=1, Labels=['UnsafePrincipal: +1']
+        Returns a PSCustomObject with Score ([int]) and Labels ([string[]]) properties.
+    .PARAMETER IdentityReferenceSID
+        SID or NTAccount string of the principal.
+    .PARAMETER IdentityReferenceClass
+        Object class of the principal (e.g. 'group', 'user').
+    .EXAMPLE
+        Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-1-0' -IdentityReferenceClass 'group'
+        # Returns Score=3, Labels=@('UnsafePrincipal: +1', 'DangerousPrincipal: +2')  (Everyone)
+    .EXAMPLE
+        Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-5-21-1234-5678-9012-1001' -IdentityReferenceClass 'group'
+        # Returns Score=2, Labels=@('UnsafePrincipal: +1', 'UnsafeGroup: +1')
+    .EXAMPLE
+        Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-5-21-1234-5678-9012-512' -IdentityReferenceClass 'group'
+        # Returns Score=0, Labels=@()  (Domain Admins is a SafePrincipal)
+    .OUTPUTS
+        [PSCustomObject] with Score ([int]) and Labels ([string[]]) properties.
+    #>
+    [CmdletBinding()]
+    [OutputType([PSCustomObject])]
+    param(
+        [Parameter()]
+        [string]$IdentityReferenceSID = '',
+
+        [Parameter()]
+        [string]$IdentityReferenceClass = ''
+    )
+
+    $sid = if ($null -ne $IdentityReferenceSID) { $IdentityReferenceSID } else { '' }
+
+    # SafePrincipal check — early return, always +0, no further modifiers
+    foreach ($pattern in $script:PrincipalDefinitionsBase.SafePrincipals) {
+        if ($pattern -match '\$$') {
+            if ($sid -match $pattern) {
+                return [PSCustomObject]@{ Score = 0; Labels = [string[]]@() }
+            }
+        } else {
+            if ($sid -eq $pattern) {
+                return [PSCustomObject]@{ Score = 0; Labels = [string[]]@() }
+            }
+        }
+    }
+
+    # DangerousPrincipal check — +3 flat regardless of objectClass; group modifier never applies
+    foreach ($pattern in $script:PrincipalDefinitionsBase.DangerousPrincipals) {
+        if ($pattern -match '\$$') {
+            if ($sid -match $pattern) {
+                return [PSCustomObject]@{
+                    Score  = 3
+                    Labels = [string[]]@('UnsafePrincipal: +1', 'DangerousPrincipal: +2')
+                }
+            }
+        } else {
+            if ($sid -eq $pattern) {
+                return [PSCustomObject]@{
+                    Score  = 3
+                    Labels = [string[]]@('UnsafePrincipal: +1', 'DangerousPrincipal: +2')
+                }
+            }
+        }
+    }
+
+    # Unsafe non-dangerous principal — accumulate UnsafePrincipal + optional UnsafeGroup
+    $score  = 1
+    $labels = [System.Collections.Generic.List[string]]::new()
+    $labels.Add('UnsafePrincipal: +1')
+
+    if ($IdentityReferenceClass -eq 'group') {
+        $score += 1
+        $labels.Add('UnsafeGroup: +1')
+    }
+
+    return [PSCustomObject]@{ Score = $score; Labels = [string[]]$labels }
+}

--- a/Private/Set/Set-LS2RiskRating.ps1
+++ b/Private/Set/Set-LS2RiskRating.ps1
@@ -1,0 +1,188 @@
+function Set-LS2RiskRating {
+    <#
+    .SYNOPSIS
+        Computes and assigns risk ratings to a collection of LS2Issue objects.
+    .DESCRIPTION
+        Performs a data-driven two-pass scoring algorithm:
+          Pass 1 - Per-issue: BaseScore + TechniqueBonus + EnabledModifier +
+                   PrincipalRisk + ObjectClassBonus + NtAuthBonus + EndpointBonus
+          Pass 2 - Cross-ESC: applies cross-technique modifiers based on related
+                   issues in the same forest
+        Clamps minimum score to 0, then maps to RiskName:
+          <=1 Informational | 2 Low | 3 Medium | 4 High | >=5 Critical
+        Mutates each LS2Issue in place; returns nothing.
+    .PARAMETER Issues
+        Array of LS2Issue objects to score.
+    .EXAMPLE
+        $allIssues = Get-FlattenedIssues
+        Set-LS2RiskRating -Issues $allIssues
+    .OUTPUTS
+        None. Modifies LS2Issue objects in place.
+    .NOTES
+        Scoring metadata is defined in Private/Data/ESCDefinitions.ps1 as
+        $script:ESCScoringMetadata, merged into $script:ESCDefinitions at load.
+        Principal definitions are in Private/Data/PrincipalDefinitions.ps1.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyCollection()]
+        [LS2Issue[]]$Issues
+    )
+
+    if ($Issues.Count -eq 0) { return }
+
+    $rawValues   = @{}
+    $scoreTrails = @{}
+
+    # ---- Pass 1: Per-issue scoring (no cross-ESC) --------------------------------- #
+    foreach ($issue in $Issues) {
+        $def = $script:ESCDefinitions[$issue.Technique]
+        if ($null -eq $def) {
+            $rawValues[$issue]   = 0
+            $scoreTrails[$issue] = [System.Collections.Generic.List[string]]::new()
+            continue
+        }
+
+        $riskValue   = $def.BaseScore
+        $riskScoring = [System.Collections.Generic.List[string]]::new()
+        $riskScoring.Add("BaseScore: $($def.BaseScore)")
+
+        # TechniqueBonus
+        if ($def.TechniqueBonus -gt 0) {
+            $riskValue += $def.TechniqueBonus
+            $riskScoring.Add("TechniqueBonus: +$($def.TechniqueBonus)")
+        }
+
+        # EnabledModifier
+        if ($def.ApplyEnabledModifier) {
+            if ($issue.Enabled -eq $true) {
+                $riskValue += 1
+                $riskScoring.Add('Enabled: +1')
+            } elseif ($issue.Enabled -eq $false) {
+                $riskValue -= 2
+                $riskScoring.Add('Disabled: -2')
+            }
+        }
+
+        # PrincipalRisk
+        if ($def.ApplyPrincipalRisk) {
+            $principalBonus = Get-PrincipalRiskBonus `
+                -IdentityReferenceSID   $issue.IdentityReferenceSID `
+                -IdentityReferenceClass $issue.IdentityReferenceClass
+            $riskValue += $principalBonus.Score
+            foreach ($lbl in $principalBonus.Labels) { $riskScoring.Add($lbl) }
+        }
+
+        # ObjectClassBonus
+        if ($def.ApplyObjectClassBonus) {
+            $objectClass = if ($null -ne $issue.ObjectClass) { $issue.ObjectClass } else { '' }
+            if ($def.ObjectClassBonuses.ContainsKey($objectClass)) {
+                $objBonus = $def.ObjectClassBonuses[$objectClass]
+                $riskValue += $objBonus
+                $riskScoring.Add("ObjectClass($objectClass): +$objBonus")
+            }
+            if ($null -ne $issue.DistinguishedName -and $issue.DistinguishedName -like '*NtAuthCertificates*') {
+                $riskValue += $def.NtAuthBonus
+                $riskScoring.Add("NtAuthCertificates: +$($def.NtAuthBonus)")
+            }
+        }
+
+        # EndpointBonus
+        if ($def.EndpointBonuses.Count -gt 0 -and
+            $null -ne $issue.EndpointAttackVector -and
+            $issue.EndpointAttackVector -ne '') {
+            if ($def.EndpointBonuses.ContainsKey($issue.EndpointAttackVector)) {
+                $epBonus = $def.EndpointBonuses[$issue.EndpointAttackVector]
+                $riskValue += $epBonus
+                $riskScoring.Add("EndpointBonus($($issue.EndpointAttackVector)): +$epBonus")
+            }
+        }
+
+        $rawValues[$issue]   = $riskValue
+        $scoreTrails[$issue] = $riskScoring
+    }
+
+    # ---- Pass 2: Cross-ESC modifiers --------------------------------------------- #
+    foreach ($issue in $Issues) {
+        $def = $script:ESCDefinitions[$issue.Technique]
+        if ($null -eq $def -or $def.CrossESCModifiers.Count -eq 0) { continue }
+
+        foreach ($modifier in $def.CrossESCModifiers) {
+
+            # Gate: only applies when this issue is disabled (if configured)
+            if ($modifier.OnlyWhenDisabled -and $issue.Enabled -ne $false) { continue }
+
+            # Find qualifying related issues in the same forest
+            $relatedIssues = $Issues | Where-Object {
+                $candidate = $_
+                if ([object]::ReferenceEquals($candidate, $issue)) { return $false }
+                if ($candidate.Forest -ne $issue.Forest)           { return $false }
+
+                # Technique must match at least one RequiredTechniquePatterns entry
+                $techniqueMatch = $false
+                foreach ($pattern in $modifier.RequiredTechniquePatterns) {
+                    if ($candidate.Technique -like $pattern) {
+                        $techniqueMatch = $true
+                        break
+                    }
+                }
+                if (-not $techniqueMatch) { return $false }
+
+                # RequiredObjectClass filter ('' = any)
+                if ($modifier.RequiredObjectClass -ne '' -and
+                    $candidate.ObjectClass -ne $modifier.RequiredObjectClass) {
+                    return $false
+                }
+
+                # OnlyEnabledMatches filter
+                if ($modifier.OnlyEnabledMatches -and $candidate.Enabled -ne $true) {
+                    return $false
+                }
+
+                return $true
+            }
+
+            $relatedIssues = @($relatedIssues)
+            if ($relatedIssues.Count -eq 0) { continue }
+
+            $crossBonus = 0
+            if ($modifier.BonusFromPrincipalRisk) {
+                foreach ($related in $relatedIssues) {
+                    $pBonus = Get-PrincipalRiskBonus `
+                        -IdentityReferenceSID   $related.IdentityReferenceSID `
+                        -IdentityReferenceClass $related.IdentityReferenceClass
+                    $crossBonus += $pBonus.Score
+                }
+                $crossBonus = [Math]::Min($crossBonus, $modifier.BonusCap)
+            } else {
+                $crossBonus = [Math]::Min($modifier.Bonus, $modifier.BonusCap)
+            }
+
+            if ($crossBonus -gt 0) {
+                $rawValues[$issue] += $crossBonus
+                $scoreTrails[$issue].Add(
+                    "CrossESC($($modifier.RequiredTechniquePatterns -join ',')): +$crossBonus"
+                )
+            }
+        }
+    }
+
+    # ---- Final: clamp, map RiskName, commit ---------------------------------------- #
+    foreach ($issue in $Issues) {
+        $def = $script:ESCDefinitions[$issue.Technique]
+        if ($null -eq $def) { continue }
+
+        $finalValue = [Math]::Max(0, $rawValues[$issue])
+
+        $riskName = if ($finalValue -le 1) { 'Informational' }
+                    elseif ($finalValue -eq 2) { 'Low' }
+                    elseif ($finalValue -eq 3) { 'Medium' }
+                    elseif ($finalValue -eq 4) { 'High' }
+                    else   { 'Critical' }
+
+        $issue.RiskValue  = $finalValue
+        $issue.RiskName   = $riskName
+        $issue.RiskScoring = [string[]]$scoreTrails[$issue]
+    }
+}

--- a/Public/Find-LS2VulnerableCA.ps1
+++ b/Public/Find-LS2VulnerableCA.ps1
@@ -338,16 +338,27 @@ function Find-LS2VulnerableCA {
                         "and request a certificate on behalf of the victim.`n`nMore info:`n  - https://posts.specterops.io/certified-pre-owned-d95910965cd2"
                 }
 
+                # Determine attack vector for scoring
+                if ($isHttp) {
+                    $endpointAttackVector = 'HTTP'
+                } elseif ($endpoint.NtlmOffered -eq $true) {
+                    $endpointAttackVector = 'HTTPS-NTLM'
+                } else {
+                    $endpointAttackVector = 'HTTPS-Kerberos'
+                }
+
                 $issue = [LS2Issue]@{
-                    Technique         = 'ESC8'
-                    Forest            = $forestName
-                    Name              = $caName
-                    DistinguishedName = $ca.distinguishedName
-                    ObjectClass       = 'pKIEnrollmentService'
-                    CAFullName        = $caFullName
-                    Issue             = $issueText
-                    Fix               = $fixText
-                    Revert            = $revertText
+                    Technique             = 'ESC8'
+                    Forest                = $forestName
+                    Name                  = $caName
+                    DistinguishedName     = $ca.distinguishedName
+                    ObjectClass           = 'pKIEnrollmentService'
+                    CAFullName            = $caFullName
+                    EndpointURL           = $url
+                    EndpointAttackVector  = $endpointAttackVector
+                    Issue                 = $issueText
+                    Fix                   = $fixText
+                    Revert                = $revertText
                 }
 
                 $dn = $ca.distinguishedName

--- a/Public/Invoke-Locksmith2.ps1
+++ b/Public/Invoke-Locksmith2.ps1
@@ -216,7 +216,13 @@ function Invoke-Locksmith2 {
         $allIssues = $allIssues | ForEach-Object { Expand-IssueByGroup $_ }
         Write-Verbose "Expansion complete. Total issues: $($allIssues.Count)"
     }
-        
+
+    # Compute risk ratings for all issues
+    if ($allIssues.Count -gt 0) {
+        Write-Verbose "Computing risk ratings for $($allIssues.Count) issue(s)..."
+        Set-LS2RiskRating -Issues $allIssues
+    }
+
     # Output based on whether Mode was specified
     if ($PSBoundParameters.ContainsKey('Mode')) {
         # Display issues in console using specified mode

--- a/Public/New-LS2Dashboard.ps1
+++ b/Public/New-LS2Dashboard.ps1
@@ -105,6 +105,8 @@ function New-LS2Dashboard {
 
     $standardColumns = @(
         'Technique'
+        @{N = 'RiskName';    E = { if ($_.RiskName)          { $_.RiskName }  else { 'Unrated' } } }
+        @{N = 'RiskValue';   E = { if ($null -ne $_.RiskValue) { $_.RiskValue } else { 'N/A'    } } }
         'Forest'
         'Name'
         'DistinguishedName'
@@ -121,6 +123,7 @@ function New-LS2Dashboard {
         @{N = 'Owner';                  E = { if ($_.Owner)                  { $_.Owner }                          else { 'N/A' } } }
         @{N = 'HasNonStandardOwner';    E = { if ($null -ne $_.HasNonStandardOwner) { $_.HasNonStandardOwner }    else { 'N/A' } } }
         @{N = 'Members';                E = { if ($_.MemberCount)            { $_.MemberCount }                    else { 'N/A' } } }
+        @{N = 'RiskScoring';            E = { if ($_.RiskScoring)            { $_.RiskScoring -join '; ' }         else { 'N/A' } } }
         @{N = 'Issue';                  E = { if ($_.Issue)                  { $_.Issue   -replace "`n", "`n`n" }  else { 'N/A' } } }
         @{N = 'Fix';                    E = { if ($_.Fix)                    { $_.Fix     -replace "`n", "`n`n" }  else { 'N/A' } } }
         @{N = 'Revert';                 E = { if ($_.Revert)                 { $_.Revert  -replace "`n", "`n`n" }  else { 'N/A' } } }
@@ -165,15 +168,23 @@ function New-LS2Dashboard {
     # Resolve logo and encode as base64 data URI for self-contained HTML
     $logoSource = $null
     $moduleBase = (Get-Module -Name Locksmith2 -ErrorAction SilentlyContinue).ModuleBase
-    foreach ($candidate in @(
-        (Join-Path $moduleBase 'Images\Locksmith2.png'),
-        (Join-Path $moduleBase '..\..\..\Images\Locksmith2.png')
-    )) {
-        if (Test-Path $candidate) {
-            $logoBytes  = [System.IO.File]::ReadAllBytes((Resolve-Path $candidate).Path)
-            $logoBase64 = [System.Convert]::ToBase64String($logoBytes)
-            $logoSource = "data:image/png;base64,$logoBase64"
-            break
+    if ($null -ne $moduleBase) {
+        foreach ($candidate in @(
+            (Join-Path $moduleBase 'Images\Locksmith2.png'),
+            (Join-Path $moduleBase '..\..\..\Images\Locksmith2.png')
+        )) {
+            try {
+                if (Test-Path -LiteralPath $candidate) {
+                    $logoBytes  = [System.IO.File]::ReadAllBytes(
+                        (Get-Item -LiteralPath $candidate -ErrorAction Stop).FullName
+                    )
+                    $logoBase64 = [System.Convert]::ToBase64String($logoBytes)
+                    $logoSource = "data:image/png;base64,$logoBase64"
+                    break
+                }
+            } catch {
+                Write-Verbose "Logo load failed for '$candidate': $_"
+            }
         }
     }
 
@@ -203,6 +214,12 @@ function New-LS2Dashboard {
         New-HTMLTableCondition -Name 'ActiveDirectoryRights' -ComparisonType string -Operator like -Value '*GenericWrite*'  -BackgroundColor '#ffa726' -Color Black
         # Status
         New-HTMLTableCondition -Name 'Enabled' -Value $true -BackgroundColor '#fff9c4' -Color Black
+        # Risk rating
+        New-HTMLTableCondition -Name 'RiskName' -Value 'Critical'     -BackgroundColor '#b71c1c' -Color White
+        New-HTMLTableCondition -Name 'RiskName' -Value 'High'         -BackgroundColor '#e53935' -Color White
+        New-HTMLTableCondition -Name 'RiskName' -Value 'Medium'       -BackgroundColor '#ff9800' -Color Black
+        New-HTMLTableCondition -Name 'RiskName' -Value 'Low'          -BackgroundColor '#fdd835' -Color Black
+        New-HTMLTableCondition -Name 'RiskName' -Value 'Informational'-BackgroundColor '#e3f2fd' -Color Black
     }
 
     # Conditional formatting for principals (different schema; most severe last so they override)

--- a/Tests/Classes/LS2AdcsObject.Tests.ps1
+++ b/Tests/Classes/LS2AdcsObject.Tests.ps1
@@ -1,7 +1,8 @@
 #requires -Version 5.1
 BeforeAll {
     $ModuleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Classes/LS2Issue.Tests.ps1
+++ b/Tests/Classes/LS2Issue.Tests.ps1
@@ -1,7 +1,8 @@
 #requires -Version 5.1
 BeforeAll {
     $ModuleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 
@@ -198,6 +199,70 @@ Describe 'LS2Issue class' -Tag 'Unit' {
         It 'should return false when argument is null' -Tag 'EdgeCase' {
             $issue = New-MockLS2Issue -Overrides $script:BaseProps
             $issue.Matches($null) | Should -BeFalse
+        }
+    }
+
+    Describe 'Risk properties' {
+        It 'RiskValue should be null by default' {
+            $issue = New-MockLS2Issue
+            $issue.RiskValue | Should -BeNullOrEmpty
+        }
+
+        It 'RiskName should be null/empty by default' {
+            $issue = New-MockLS2Issue
+            $issue.RiskName | Should -BeNullOrEmpty
+        }
+
+        It 'RiskScoring should be null by default' {
+            $issue = New-MockLS2Issue
+            $issue.RiskScoring | Should -BeNullOrEmpty
+        }
+
+        It 'EndpointURL should be null/empty by default' {
+            $issue = New-MockLS2Issue
+            $issue.EndpointURL | Should -BeNullOrEmpty
+        }
+
+        It 'EndpointAttackVector should be null/empty by default' {
+            $issue = New-MockLS2Issue
+            $issue.EndpointAttackVector | Should -BeNullOrEmpty
+        }
+
+        It 'constructor sets RiskValue from hashtable' {
+            $issue = New-MockLS2Issue -Overrides @{ RiskValue = 4 }
+            $issue.RiskValue | Should -Be 4
+        }
+
+        It 'constructor sets RiskName from hashtable' {
+            $issue = New-MockLS2Issue -Overrides @{ RiskName = 'High' }
+            $issue.RiskName | Should -Be 'High'
+        }
+
+        It 'constructor sets RiskScoring from hashtable' {
+            $issue = New-MockLS2Issue -Overrides @{ RiskScoring = @('BaseScore: 3', 'Enabled: +1') }
+            $issue.RiskScoring | Should -Be @('BaseScore: 3', 'Enabled: +1')
+        }
+
+        It 'constructor sets EndpointURL from hashtable' {
+            $issue = New-MockLS2Issue -Overrides @{ EndpointURL = 'http://ca.contoso.com/certsrv/' }
+            $issue.EndpointURL | Should -Be 'http://ca.contoso.com/certsrv/'
+        }
+
+        It 'constructor sets EndpointAttackVector from hashtable' {
+            $issue = New-MockLS2Issue -Overrides @{ EndpointAttackVector = 'HTTP' }
+            $issue.EndpointAttackVector | Should -Be 'HTTP'
+        }
+
+        It 'RiskValue can be set post-construction' {
+            $issue = New-MockLS2Issue
+            $issue.RiskValue = 5
+            $issue.RiskValue | Should -Be 5
+        }
+
+        It 'RiskScoring can be appended post-construction' {
+            $issue = New-MockLS2Issue
+            $issue.RiskScoring = @('BaseScore: 0', 'TechniqueBonus: +1')
+            $issue.RiskScoring.Count | Should -Be 2
         }
     }
 }

--- a/Tests/Classes/LS2Principal.Tests.ps1
+++ b/Tests/Classes/LS2Principal.Tests.ps1
@@ -1,7 +1,8 @@
 #requires -Version 5.1
 BeforeAll {
     $ModuleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 Describe 'LS2Principal class' -Tag 'Unit' {

--- a/Tests/Integration/Find-LS2VulnerableTemplate.Integration.Tests.ps1
+++ b/Tests/Integration/Find-LS2VulnerableTemplate.Integration.Tests.ps1
@@ -5,11 +5,13 @@
 
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 
     $script:TestForest = $env:LS2_TEST_FOREST
 }

--- a/Tests/Integration/Get-WebEnrollmentEndpointStatus.Integration.Tests.ps1
+++ b/Tests/Integration/Get-WebEnrollmentEndpointStatus.Integration.Tests.ps1
@@ -6,11 +6,13 @@
 
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 
     $script:TestForest = $env:LS2_TEST_FOREST
     $script:TestCaHost = $env:LS2_TEST_CA_HOST

--- a/Tests/Integration/Invoke-Locksmith2.Integration.Tests.ps1
+++ b/Tests/Integration/Invoke-Locksmith2.Integration.Tests.ps1
@@ -5,11 +5,13 @@
 
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 
     $script:TestForest = $env:LS2_TEST_FOREST
     # Optional: populate from environment

--- a/Tests/Private/Convert/Convert-IdentityReferenceToNTAccount.Tests.ps1
+++ b/Tests/Private/Convert/Convert-IdentityReferenceToNTAccount.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Convert/Convert-IdentityReferenceToSid.Tests.ps1
+++ b/Tests/Private/Convert/Convert-IdentityReferenceToSid.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Convert/Expand-GroupMembership.Tests.ps1
+++ b/Tests/Private/Convert/Expand-GroupMembership.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Convert/Resolve-Principal.Tests.ps1
+++ b/Tests/Private/Convert/Resolve-Principal.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Data/ESCDefinitions.Tests.ps1
+++ b/Tests/Private/Data/ESCDefinitions.Tests.ps1
@@ -107,4 +107,128 @@ Describe 'ESCDefinitions data' -Tag 'Unit' {
             $script:ESCDefinitions[$_].RevertTemplate | Should -Not -BeNullOrEmpty
         }
     }
+
+    Context 'Each technique has required scoring keys' {
+        $AllTechniques = @(
+            'ESC1', 'ESC2', 'ESC3c1', 'ESC3c2',
+            'ESC4a', 'ESC4o',
+            'ESC5a', 'ESC5o',
+            'ESC6', 'ESC7a', 'ESC7m',
+            'ESC8', 'ESC9', 'ESC11', 'ESC13', 'ESC15', 'ESC16',
+            'Auditing', 'SchemaV1'
+        )
+
+        It '<_> should have a BaseScore key' -ForEach $AllTechniques {
+            $script:ESCDefinitions[$_].Keys | Should -Contain 'BaseScore'
+        }
+
+        It '<_> BaseScore should be an integer between 0 and 3' -ForEach $AllTechniques {
+            $def = $script:ESCDefinitions[$_]
+            $def.BaseScore | Should -BeOfType [int]
+            $def.BaseScore | Should -BeGreaterOrEqual 0
+            $def.BaseScore | Should -BeLessOrEqual 3
+        }
+
+        It '<_> should have a TechniqueBonus key' -ForEach $AllTechniques {
+            $script:ESCDefinitions[$_].Keys | Should -Contain 'TechniqueBonus'
+        }
+
+        It '<_> TechniqueBonus should be a non-negative integer' -ForEach $AllTechniques {
+            $def = $script:ESCDefinitions[$_]
+            $def.TechniqueBonus | Should -BeOfType [int]
+            $def.TechniqueBonus | Should -BeGreaterOrEqual 0
+        }
+
+        It '<_> should have an ApplyEnabledModifier key' -ForEach $AllTechniques {
+            $script:ESCDefinitions[$_].Keys | Should -Contain 'ApplyEnabledModifier'
+        }
+
+        It '<_> ApplyEnabledModifier should be a bool' -ForEach $AllTechniques {
+            $script:ESCDefinitions[$_].ApplyEnabledModifier | Should -BeOfType [bool]
+        }
+
+        It '<_> should have an ApplyPrincipalRisk key' -ForEach $AllTechniques {
+            $script:ESCDefinitions[$_].Keys | Should -Contain 'ApplyPrincipalRisk'
+        }
+
+        It '<_> ApplyPrincipalRisk should be a bool' -ForEach $AllTechniques {
+            $script:ESCDefinitions[$_].ApplyPrincipalRisk | Should -BeOfType [bool]
+        }
+
+        It '<_> should have an ApplyObjectClassBonus key' -ForEach $AllTechniques {
+            $script:ESCDefinitions[$_].Keys | Should -Contain 'ApplyObjectClassBonus'
+        }
+
+        It '<_> ApplyObjectClassBonus should be a bool' -ForEach $AllTechniques {
+            $script:ESCDefinitions[$_].ApplyObjectClassBonus | Should -BeOfType [bool]
+        }
+
+        It '<_> should have an ObjectClassBonuses key' -ForEach $AllTechniques {
+            $script:ESCDefinitions[$_].Keys | Should -Contain 'ObjectClassBonuses'
+        }
+
+        It '<_> ObjectClassBonuses should be a hashtable' -ForEach $AllTechniques {
+            $script:ESCDefinitions[$_].ObjectClassBonuses | Should -BeOfType [hashtable]
+        }
+
+        It '<_> should have a NtAuthBonus key' -ForEach $AllTechniques {
+            $script:ESCDefinitions[$_].Keys | Should -Contain 'NtAuthBonus'
+        }
+
+        It '<_> NtAuthBonus should be a non-negative integer' -ForEach $AllTechniques {
+            $def = $script:ESCDefinitions[$_]
+            $def.NtAuthBonus | Should -BeOfType [int]
+            $def.NtAuthBonus | Should -BeGreaterOrEqual 0
+        }
+
+        It '<_> should have an EndpointBonuses key' -ForEach $AllTechniques {
+            $script:ESCDefinitions[$_].Keys | Should -Contain 'EndpointBonuses'
+        }
+
+        It '<_> EndpointBonuses should be a hashtable' -ForEach $AllTechniques {
+            $script:ESCDefinitions[$_].EndpointBonuses | Should -BeOfType [hashtable]
+        }
+
+        It '<_> should have a CrossESCModifiers key' -ForEach $AllTechniques {
+            $script:ESCDefinitions[$_].Keys | Should -Contain 'CrossESCModifiers'
+        }
+
+        It '<_> CrossESCModifiers should be an array' -ForEach $AllTechniques {
+            # array or empty array - just check it's not a scalar non-collection
+            $val = $script:ESCDefinitions[$_].CrossESCModifiers
+            ($val -is [array]) -or ($val -is [System.Collections.IEnumerable] -and $val -isnot [string]) -or ($val.Count -eq 0) | Should -BeTrue
+        }
+    }
+
+    Context 'ESC5a and ESC5o have populated ObjectClassBonuses' {
+        It 'ESC5a ObjectClassBonuses should include pKIEnrollmentService' {
+            $script:ESCDefinitions['ESC5a'].ObjectClassBonuses.Keys | Should -Contain 'pKIEnrollmentService'
+        }
+
+        It 'ESC5a NtAuthBonus should be 2' {
+            $script:ESCDefinitions['ESC5a'].NtAuthBonus | Should -Be 2
+        }
+
+        It 'ESC5o ObjectClassBonuses should include pKIEnrollmentService' {
+            $script:ESCDefinitions['ESC5o'].ObjectClassBonuses.Keys | Should -Contain 'pKIEnrollmentService'
+        }
+
+        It 'ESC5o NtAuthBonus should be 2' {
+            $script:ESCDefinitions['ESC5o'].NtAuthBonus | Should -Be 2
+        }
+    }
+
+    Context 'ESC8 has EndpointBonuses for all three attack vectors' {
+        It 'ESC8 EndpointBonuses should contain HTTP' {
+            $script:ESCDefinitions['ESC8'].EndpointBonuses.Keys | Should -Contain 'HTTP'
+        }
+
+        It 'ESC8 EndpointBonuses should contain HTTPS-NTLM' {
+            $script:ESCDefinitions['ESC8'].EndpointBonuses.Keys | Should -Contain 'HTTPS-NTLM'
+        }
+
+        It 'ESC8 EndpointBonuses should contain HTTPS-Kerberos' {
+            $script:ESCDefinitions['ESC8'].EndpointBonuses.Keys | Should -Contain 'HTTPS-Kerberos'
+        }
+    }
 }

--- a/Tests/Private/Get/Get-FlattenedIssues.Tests.ps1
+++ b/Tests/Private/Get/Get-FlattenedIssues.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Get/Get-ModuleThatLoadedThisFunction.Tests.ps1
+++ b/Tests/Private/Get/Get-ModuleThatLoadedThisFunction.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 Describe 'Get-ModuleThatLoadedThisFunction' -Tag 'Unit' {

--- a/Tests/Private/Initialize/Initialize-AdcsObjectStore.Tests.ps1
+++ b/Tests/Private/Initialize/Initialize-AdcsObjectStore.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Initialize/Initialize-DirectoryConnections.Tests.ps1
+++ b/Tests/Private/Initialize/Initialize-DirectoryConnections.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 Describe 'Initialize-DirectoryConnections' -Tag 'Integration' {

--- a/Tests/Private/Initialize/Initialize-LS2Scan.Tests.ps1
+++ b/Tests/Private/Initialize/Initialize-LS2Scan.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 Describe 'Initialize-LS2Scan' -Tag 'Unit' {

--- a/Tests/Private/Initialize/Initialize-PrincipalDefinitions.Tests.ps1
+++ b/Tests/Private/Initialize/Initialize-PrincipalDefinitions.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 Describe 'Initialize-PrincipalDefinitions' -Tag 'Unit' {

--- a/Tests/Private/New/New-AuthenticatedDirectoryEntry.Tests.ps1
+++ b/Tests/Private/New/New-AuthenticatedDirectoryEntry.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 # New-AuthenticatedDirectoryEntry calls New-Object System.DirectoryServices.DirectoryEntry with real

--- a/Tests/Private/New/New-GCSearcher.Tests.ps1
+++ b/Tests/Private/New/New-GCSearcher.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 Describe 'New-GCSearcher' -Tag 'Unit' {

--- a/Tests/Private/New/New-LDAPSearcher.Tests.ps1
+++ b/Tests/Private/New/New-LDAPSearcher.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 Describe 'New-LDAPSearcher' -Tag 'Unit' {

--- a/Tests/Private/Set/Get-PrincipalRiskBonus.Tests.ps1
+++ b/Tests/Private/Set/Get-PrincipalRiskBonus.Tests.ps1
@@ -1,0 +1,147 @@
+#requires -Version 5.1
+BeforeDiscovery {
+    $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
+}
+
+BeforeAll {
+    $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
+}
+
+Describe 'Get-PrincipalRiskBonus' -Tag 'Unit' {
+    InModuleScope 'Locksmith2' {
+
+        # ------------------------------------------------------------------ #
+        #  SafePrincipal — always early-return, Score=0, Labels=@()
+        # ------------------------------------------------------------------ #
+        Context 'SafePrincipal' {
+            It 'Domain Admins (-512$) returns Score=0 and empty Labels' {
+                $result = Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-5-21-1234-5678-9012-512' -IdentityReferenceClass 'group'
+                $result.Score  | Should -Be 0
+                $result.Labels | Should -BeNullOrEmpty
+            }
+
+            It 'Enterprise Admins (-519$) returns Score=0 and empty Labels' {
+                $result = Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-5-21-1234-5678-9012-519' -IdentityReferenceClass 'group'
+                $result.Score  | Should -Be 0
+                $result.Labels | Should -BeNullOrEmpty
+            }
+
+            It 'SYSTEM (-18$) returns Score=0 and empty Labels' {
+                $result = Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-5-18' -IdentityReferenceClass 'user'
+                $result.Score  | Should -Be 0
+                $result.Labels | Should -BeNullOrEmpty
+            }
+        }
+
+        # ------------------------------------------------------------------ #
+        #  Unsafe individual — not safe, not group, not dangerous
+        # ------------------------------------------------------------------ #
+        Context 'Unsafe individual' {
+            It 'returns Score=1 with only UnsafePrincipal label' {
+                $result = Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-5-21-1234-5678-9012-1001' -IdentityReferenceClass 'user'
+                $result.Score  | Should -Be 1
+                $result.Labels | Should -HaveCount 1
+                $result.Labels | Should -Contain 'UnsafePrincipal: +1'
+            }
+
+            It 'empty SID with user class returns Score=1' {
+                $result = Get-PrincipalRiskBonus -IdentityReferenceSID '' -IdentityReferenceClass 'user'
+                $result.Score  | Should -Be 1
+                $result.Labels | Should -Contain 'UnsafePrincipal: +1'
+            }
+        }
+
+        # ------------------------------------------------------------------ #
+        #  Unsafe group — not safe, class=group, not dangerous
+        # ------------------------------------------------------------------ #
+        Context 'Unsafe group' {
+            It 'returns Score=2 with UnsafePrincipal and UnsafeGroup labels' {
+                $result = Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-5-21-1234-5678-9012-1001' -IdentityReferenceClass 'group'
+                $result.Score  | Should -Be 2
+                $result.Labels | Should -HaveCount 2
+                $result.Labels | Should -Contain 'UnsafePrincipal: +1'
+                $result.Labels | Should -Contain 'UnsafeGroup: +1'
+            }
+
+            It 'does not include DangerousPrincipal label for a non-dangerous group' {
+                $result = Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-5-21-1234-5678-9012-1001' -IdentityReferenceClass 'group'
+                $result.Labels | Should -Not -Contain 'DangerousPrincipal: +1'
+            }
+        }
+
+        # ------------------------------------------------------------------ #
+        #  DangerousPrincipal individual — not group
+        # ------------------------------------------------------------------ #
+        Context 'DangerousPrincipal individual' {
+            It 'Authenticated Users (S-1-5-11) with user class returns Score=3' {
+                $result = Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-5-11' -IdentityReferenceClass 'user'
+                $result.Score  | Should -Be 3
+                $result.Labels | Should -HaveCount 2
+                $result.Labels | Should -Contain 'UnsafePrincipal: +1'
+                $result.Labels | Should -Contain 'DangerousPrincipal: +2'
+            }
+
+            It 'does not include UnsafeGroup label for a dangerous principal (any class)' {
+                $result = Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-5-11' -IdentityReferenceClass 'user'
+                $result.Labels | Should -Not -Contain 'UnsafeGroup: +1'
+            }
+        }
+
+        # ------------------------------------------------------------------ #
+        #  DangerousPrincipal group — group modifier does NOT apply; Score=3 flat
+        # ------------------------------------------------------------------ #
+        Context 'DangerousPrincipal group' {
+            It 'Everyone (S-1-1-0) with group class returns Score=3 (no UnsafeGroup modifier)' {
+                $result = Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-1-0' -IdentityReferenceClass 'group'
+                $result.Score  | Should -Be 3
+                $result.Labels | Should -HaveCount 2
+                $result.Labels | Should -Contain 'UnsafePrincipal: +1'
+                $result.Labels | Should -Contain 'DangerousPrincipal: +2'
+            }
+
+            It 'Everyone (S-1-1-0) with group class does NOT get UnsafeGroup label' {
+                $result = Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-1-0' -IdentityReferenceClass 'group'
+                $result.Labels | Should -Not -Contain 'UnsafeGroup: +1'
+            }
+
+            It 'Domain Users (-513$) with group class returns Score=3' {
+                $result = Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-5-21-1234-5678-9012-513' -IdentityReferenceClass 'group'
+                $result.Score  | Should -Be 3
+                $result.Labels | Should -Contain 'DangerousPrincipal: +2'
+            }
+
+            It 'Domain Computers (-515$) with group class returns Score=3' {
+                $result = Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-5-21-1234-5678-9012-515' -IdentityReferenceClass 'group'
+                $result.Score  | Should -Be 3
+                $result.Labels | Should -Contain 'DangerousPrincipal: +2'
+            }
+
+            It 'BUILTIN\Users (S-1-5-32-545) with group class returns Score=3 with 2 labels' {
+                $result = Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-5-32-545' -IdentityReferenceClass 'group'
+                $result.Score  | Should -Be 3
+                $result.Labels | Should -HaveCount 2
+            }
+        }
+
+        # ------------------------------------------------------------------ #
+        #  Label ordering
+        # ------------------------------------------------------------------ #
+        Context 'Label ordering' {
+            It 'dangerous principal labels are ordered: UnsafePrincipal, DangerousPrincipal' {
+                $result = Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-1-0' -IdentityReferenceClass 'group'
+                $result.Labels[0] | Should -Be 'UnsafePrincipal: +1'
+                $result.Labels[1] | Should -Be 'DangerousPrincipal: +2'
+            }
+
+            It 'unsafe group labels are ordered: UnsafePrincipal, UnsafeGroup' {
+                $result = Get-PrincipalRiskBonus -IdentityReferenceSID 'S-1-5-21-1234-5678-9012-1001' -IdentityReferenceClass 'group'
+                $result.Labels[0] | Should -Be 'UnsafePrincipal: +1'
+                $result.Labels[1] | Should -Be 'UnsafeGroup: +1'
+            }
+        }
+    }
+}

--- a/Tests/Private/Set/Set-AuthorizedSignature.Tests.ps1
+++ b/Tests/Private/Set/Set-AuthorizedSignature.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-CAAdministrator.Tests.ps1
+++ b/Tests/Private/Set/Set-CAAdministrator.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-CAAdministratorClassification.Tests.ps1
+++ b/Tests/Private/Set/Set-CAAdministratorClassification.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-CAAuditFilter.Tests.ps1
+++ b/Tests/Private/Set/Set-CAAuditFilter.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-CACertificateManager.Tests.ps1
+++ b/Tests/Private/Set/Set-CACertificateManager.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-CACertificateManagerClassification.Tests.ps1
+++ b/Tests/Private/Set/Set-CACertificateManagerClassification.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-CAComputerPrincipal.Tests.ps1
+++ b/Tests/Private/Set/Set-CAComputerPrincipal.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-CADisableExtensionList.Tests.ps1
+++ b/Tests/Private/Set/Set-CADisableExtensionList.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-CAEditFlags.Tests.ps1
+++ b/Tests/Private/Set/Set-CAEditFlags.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-CAInterfaceFlags.Tests.ps1
+++ b/Tests/Private/Set/Set-CAInterfaceFlags.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-CAWebEnrollmentEndpoints.Tests.ps1
+++ b/Tests/Private/Set/Set-CAWebEnrollmentEndpoints.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-EKUChecks.Tests.ps1
+++ b/Tests/Private/Set/Set-EKUChecks.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-Editor.Tests.ps1
+++ b/Tests/Private/Set/Set-Editor.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-Enrollee.Tests.ps1
+++ b/Tests/Private/Set/Set-Enrollee.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-HasNonStandardOwner.Tests.ps1
+++ b/Tests/Private/Set/Set-HasNonStandardOwner.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-LS2RiskRating.Tests.ps1
+++ b/Tests/Private/Set/Set-LS2RiskRating.Tests.ps1
@@ -1,0 +1,516 @@
+#requires -Version 5.1
+BeforeDiscovery {
+    $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
+}
+
+BeforeAll {
+    $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
+    Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
+}
+
+Describe 'Set-LS2RiskRating' -Tag 'Unit' {
+    InModuleScope 'Locksmith2' {
+
+        BeforeEach {
+            $script:IssueStore         = @{}
+            $script:PrincipalStore     = @{}
+            $script:AdcsObjectStore    = @{}
+            $script:DomainStore        = @{}
+            $script:InitializingStores = $false
+        }
+
+        # ------------------------------------------------------------------ #
+        #  Basic contract
+        # ------------------------------------------------------------------ #
+        Context 'Function contract' {
+            It 'Set-LS2RiskRating is available in module scope' {
+                Get-Command 'Set-LS2RiskRating' -ErrorAction SilentlyContinue | Should -Not -BeNullOrEmpty
+            }
+
+            It 'accepts an array of LS2Issue objects without throwing' {
+                $issue = New-MockLS2Issue -Overrides @{ Technique = 'Auditing'; CAFullName = 'srv\CA' }
+                { Set-LS2RiskRating -Issues @($issue) } | Should -Not -Throw
+            }
+
+            It 'accepts an empty array without throwing' {
+                { Set-LS2RiskRating -Issues @() } | Should -Not -Throw
+            }
+        }
+
+        # ------------------------------------------------------------------ #
+        #  Simple per-technique scoring (no cross-ESC complications)
+        # ------------------------------------------------------------------ #
+        Context 'Single-issue scoring - CA techniques' {
+            It 'Auditing gets RiskValue 3 (Medium)' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique = 'Auditing'
+                    CAFullName = 'srv\CA'
+                    Forest    = 'contoso.com'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                $issue.RiskValue | Should -Be 3
+                $issue.RiskName  | Should -Be 'Medium'
+            }
+
+            It 'ESC11 gets RiskValue 3 (Medium)' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique = 'ESC11'
+                    CAFullName = 'srv\CA'
+                    Forest    = 'contoso.com'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                $issue.RiskValue | Should -Be 3
+                $issue.RiskName  | Should -Be 'Medium'
+            }
+
+            It 'ESC8 HTTP endpoint gets RiskValue 5 (Critical)' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique            = 'ESC8'
+                    CAFullName           = 'srv\CA'
+                    Forest               = 'contoso.com'
+                    EndpointAttackVector = 'HTTP'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                # BaseScore=3 + EndpointBonus(HTTP)=2 = 5
+                $issue.RiskValue | Should -Be 5
+                $issue.RiskName  | Should -Be 'Critical'
+            }
+
+            It 'ESC8 HTTPS-NTLM endpoint gets RiskValue 5 (Critical)' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique            = 'ESC8'
+                    CAFullName           = 'srv\CA'
+                    Forest               = 'contoso.com'
+                    EndpointAttackVector = 'HTTPS-NTLM'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                $issue.RiskValue | Should -Be 5
+                $issue.RiskName  | Should -Be 'Critical'
+            }
+
+            It 'ESC8 HTTPS-Kerberos endpoint gets RiskValue 4 (High)' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique            = 'ESC8'
+                    CAFullName           = 'srv\CA'
+                    Forest               = 'contoso.com'
+                    EndpointAttackVector = 'HTTPS-Kerberos'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                # BaseScore=3 + EndpointBonus(HTTPS-Kerberos)=1 = 4
+                $issue.RiskValue | Should -Be 4
+                $issue.RiskName  | Should -Be 'High'
+            }
+        }
+
+        Context 'Single-issue scoring - template techniques' {
+            It 'SchemaV1 enabled gets RiskValue 2 (Low)' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique = 'SchemaV1'
+                    Enabled   = $true
+                    Forest    = 'contoso.com'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                # BaseScore=1 + Enabled(+1) = 2
+                $issue.RiskValue | Should -Be 2
+                $issue.RiskName  | Should -Be 'Low'
+            }
+
+            It 'SchemaV1 disabled gets RiskValue 0 (Informational, clamped from -1)' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique = 'SchemaV1'
+                    Enabled   = $false
+                    Forest    = 'contoso.com'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                # BaseScore=1 + Disabled(-2) = -1 -> clamped to 0
+                $issue.RiskValue | Should -Be 0
+                $issue.RiskName  | Should -Be 'Informational'
+            }
+
+            It 'ESC1 enabled with SafePrincipal gets RiskValue 2 (Low)' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC1'
+                    Enabled                = $true
+                    Forest                 = 'contoso.com'
+                    IdentityReferenceSID   = 'S-1-5-21-1234-5678-9012-512'  # Domain Admins (-512$)
+                    IdentityReferenceClass = 'group'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                # 0 + TechBonus(1) + Enabled(+1) + SafePrincipal(+0) = 2
+                $issue.RiskValue | Should -Be 2
+                $issue.RiskName  | Should -Be 'Low'
+            }
+
+            It 'ESC1 enabled with non-dangerous group gets RiskValue 4 (High)' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC1'
+                    Enabled                = $true
+                    Forest                 = 'contoso.com'
+                    IdentityReferenceSID   = 'S-1-5-21-1234-5678-9012-1001'
+                    IdentityReferenceClass = 'group'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                # 0 + 1 + 1 + UnsafePrincipal(+1) + UnsafeGroup(+1) = 4
+                $issue.RiskValue | Should -Be 4
+                $issue.RiskName  | Should -Be 'High'
+            }
+
+            It 'ESC1 enabled with DangerousPrincipal (Everyone) gets RiskValue 5 (Critical)' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC1'
+                    Enabled                = $true
+                    Forest                 = 'contoso.com'
+                    IdentityReferenceSID   = 'S-1-1-0'  # Everyone
+                    IdentityReferenceClass = 'group'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                # 0 + 1 + 1 + UnsafePrincipal(+1) + UnsafeGroup(+1) + DangerousPrincipal(+1) = 5
+                $issue.RiskValue | Should -Be 5
+                $issue.RiskName  | Should -Be 'Critical'
+            }
+
+            It 'ESC1 disabled with SafePrincipal gets RiskValue 0 (Informational, clamped from -1)' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC1'
+                    Enabled                = $false
+                    Forest                 = 'contoso.com'
+                    IdentityReferenceSID   = 'S-1-5-21-1234-5678-9012-512'
+                    IdentityReferenceClass = 'group'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                # 0 + 1 + Disabled(-2) + SafePrincipal(+0) = -1 -> clamped 0
+                $issue.RiskValue | Should -Be 0
+                $issue.RiskName  | Should -Be 'Informational'
+            }
+        }
+
+        Context 'Single-issue scoring - ESC5 object class bonuses' {
+            It 'ESC5a on pKIEnrollmentService with non-dangerous group gets RiskValue 4 (High)' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC5a'
+                    Forest                 = 'contoso.com'
+                    ObjectClass            = 'pKIEnrollmentService'
+                    DistinguishedName      = 'CN=MyCA,CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
+                    IdentityReferenceSID   = 'S-1-5-21-1234-5678-9012-1001'
+                    IdentityReferenceClass = 'group'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                # BaseScore=0 + ObjClass(pKIEnrollmentService=2) + UnsafePrincipal(+1) + UnsafeGroup(+1) = 4
+                $issue.RiskValue | Should -Be 4
+                $issue.RiskName  | Should -Be 'High'
+            }
+
+            It 'ESC5a on pKIEnrollmentService with DangerousPrincipal gets RiskValue 5 (Critical)' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC5a'
+                    Forest                 = 'contoso.com'
+                    ObjectClass            = 'pKIEnrollmentService'
+                    DistinguishedName      = 'CN=MyCA,CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
+                    IdentityReferenceSID   = 'S-1-1-0'
+                    IdentityReferenceClass = 'group'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                # 0 + ObjClass(2) + UnsafePrincipal(+1) + UnsafeGroup(+1) + DangerousPrincipal(+1) = 5
+                $issue.RiskValue | Should -Be 5
+                $issue.RiskName  | Should -Be 'Critical'
+            }
+
+            It 'ESC5a on NtAuthCertificates DN gets NtAuthBonus (+2) stacked with objectClass bonus' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC5a'
+                    Forest                 = 'contoso.com'
+                    ObjectClass            = 'certificationAuthority'
+                    DistinguishedName      = 'CN=NtAuthCertificates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
+                    IdentityReferenceSID   = 'S-1-1-0'  # DangerousPrincipal
+                    IdentityReferenceClass = 'group'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                # 0 + ObjClass(certificationAuthority=2) + NtAuthBonus(2) + UnsafePrincipal(+1) + UnsafeGroup(+1) + DangerousPrincipal(+1) = 7
+                $issue.RiskValue | Should -BeGreaterOrEqual 5
+                $issue.RiskName  | Should -Be 'Critical'
+            }
+        }
+
+        # ------------------------------------------------------------------ #
+        #  Cross-ESC modifier tests
+        # ------------------------------------------------------------------ #
+        Context 'Cross-ESC: ESC6 bidirectional with ESC9 and ESC16' {
+            It 'ESC6 alone gets RiskValue 3 (no cross-ESC bonus)' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique  = 'ESC6'
+                    CAFullName = 'srv\CA'
+                    Forest     = 'contoso.com'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                $issue.RiskValue | Should -Be 3
+            }
+
+            It 'ESC6 gets RiskValue 5 (Critical) when ESC9 exists in same forest' {
+                $esc6 = New-MockLS2Issue -Overrides @{
+                    Technique  = 'ESC6'
+                    CAFullName = 'srv\CA'
+                    Forest     = 'contoso.com'
+                }
+                $esc9 = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC9'
+                    Enabled                = $true
+                    Forest                 = 'contoso.com'
+                    IdentityReferenceSID   = 'S-1-5-21-1234-5678-9012-1001'
+                    IdentityReferenceClass = 'group'
+                }
+                Set-LS2RiskRating -Issues @($esc6, $esc9)
+                $esc6.RiskValue | Should -Be 5
+                $esc6.RiskName  | Should -Be 'Critical'
+            }
+
+            It 'ESC6 gets RiskValue 5 (Critical) when ESC16 exists in same forest' {
+                $esc6 = New-MockLS2Issue -Overrides @{
+                    Technique  = 'ESC6'
+                    CAFullName = 'srv\CA'
+                    Forest     = 'contoso.com'
+                }
+                $esc16 = New-MockLS2Issue -Overrides @{
+                    Technique  = 'ESC16'
+                    CAFullName = 'srv\CA'
+                    Forest     = 'contoso.com'
+                }
+                Set-LS2RiskRating -Issues @($esc6, $esc16)
+                $esc6.RiskValue | Should -Be 5
+            }
+
+            It 'ESC16 alone gets RiskValue 3 (no cross-ESC bonus)' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique  = 'ESC16'
+                    CAFullName = 'srv\CA'
+                    Forest     = 'contoso.com'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                $issue.RiskValue | Should -Be 3
+            }
+
+            It 'ESC16 gets RiskValue 5 (Critical) when ESC6 exists in same forest' {
+                $esc16 = New-MockLS2Issue -Overrides @{
+                    Technique  = 'ESC16'
+                    CAFullName = 'srv\CA'
+                    Forest     = 'contoso.com'
+                }
+                $esc6 = New-MockLS2Issue -Overrides @{
+                    Technique  = 'ESC6'
+                    CAFullName = 'srv\CA'
+                    Forest     = 'contoso.com'
+                }
+                Set-LS2RiskRating -Issues @($esc16, $esc6)
+                $esc16.RiskValue | Should -Be 5
+                $esc16.RiskName  | Should -Be 'Critical'
+            }
+
+            It 'ESC9 enabled group alone gets RiskValue 3 (Medium, no ESC6 cross)' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC9'
+                    Enabled                = $true
+                    Forest                 = 'contoso.com'
+                    IdentityReferenceSID   = 'S-1-5-21-1234-5678-9012-1001'
+                    IdentityReferenceClass = 'group'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                # 0 + 0 + Enabled(+1) + UnsafePrincipal(+1) + UnsafeGroup(+1) = 3
+                $issue.RiskValue | Should -Be 3
+                $issue.RiskName  | Should -Be 'Medium'
+            }
+
+            It 'ESC9 enabled group gets RiskValue 4 (High) when ESC6 exists in same forest' {
+                $esc9 = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC9'
+                    Enabled                = $true
+                    Forest                 = 'contoso.com'
+                    IdentityReferenceSID   = 'S-1-5-21-1234-5678-9012-1001'
+                    IdentityReferenceClass = 'group'
+                }
+                $esc6 = New-MockLS2Issue -Overrides @{
+                    Technique  = 'ESC6'
+                    CAFullName = 'srv\CA'
+                    Forest     = 'contoso.com'
+                }
+                Set-LS2RiskRating -Issues @($esc9, $esc6)
+                # 0 + 0 + 1 + UnsafePrincipal(+1) + UnsafeGroup(+1) + ESC6Cross(+2) = 5
+                $esc9.RiskValue | Should -Be 5
+                $esc9.RiskName  | Should -Be 'Critical'
+            }
+
+            It 'cross-ESC does not apply across different forests' {
+                $esc9 = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC9'
+                    Enabled                = $true
+                    Forest                 = 'contoso.com'
+                    IdentityReferenceSID   = 'S-1-5-21-1234-5678-9012-1001'
+                    IdentityReferenceClass = 'group'
+                }
+                $esc6 = New-MockLS2Issue -Overrides @{
+                    Technique  = 'ESC6'
+                    CAFullName = 'srv\CA'
+                    Forest     = 'fabrikam.com'  # different forest
+                }
+                Set-LS2RiskRating -Issues @($esc9, $esc6)
+                $esc9.RiskValue | Should -Be 3  # no cross-ESC bonus
+            }
+        }
+
+        Context 'Cross-ESC: ESC3c2 elevated by ESC3c1/ESC2' {
+            It 'ESC3c2 enabled group alone gets RiskValue 3 (Medium)' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC3c2'
+                    Enabled                = $true
+                    Forest                 = 'contoso.com'
+                    IdentityReferenceSID   = 'S-1-5-21-1234-5678-9012-1001'
+                    IdentityReferenceClass = 'group'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                # 0 + 0 + Enabled(+1) + UnsafePrincipal(+1) + UnsafeGroup(+1) = 3
+                $issue.RiskValue | Should -Be 3
+                $issue.RiskName  | Should -Be 'Medium'
+            }
+
+            It 'ESC3c2 enabled group gets RiskValue 4 when enabled ESC3c1 with DangerousPrincipal exists' {
+                $esc3c2 = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC3c2'
+                    Enabled                = $true
+                    Forest                 = 'contoso.com'
+                    IdentityReferenceSID   = 'S-1-5-21-1234-5678-9012-1001'
+                    IdentityReferenceClass = 'group'
+                }
+                $esc3c1 = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC3c1'
+                    Enabled                = $true
+                    Forest                 = 'contoso.com'
+                    IdentityReferenceSID   = 'S-1-1-0'  # DangerousPrincipal -> re-eval = 2
+                    IdentityReferenceClass = 'group'
+                }
+                Set-LS2RiskRating -Issues @($esc3c2, $esc3c1)
+                # ESC3c2: 0 + 0 + Enabled(+1) + UnsafePrincipal(+1) + UnsafeGroup(+1) + CrossESC(re-eval=3, cap=2) = 5
+                $esc3c2.RiskValue | Should -Be 5
+                $esc3c2.RiskName  | Should -Be 'Critical'
+            }
+        }
+
+        Context 'Cross-ESC: disabled template + ESC5' {
+            It 'disabled ESC1 gets cross-ESC bonus from ESC5a on pKIEnrollmentService with DangerousPrincipal' {
+                $esc1 = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC1'
+                    Enabled                = $false
+                    Forest                 = 'contoso.com'
+                    IdentityReferenceSID   = 'S-1-5-21-1234-5678-9012-512'  # SafePrincipal
+                    IdentityReferenceClass = 'group'
+                }
+                $esc5a = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC5a'
+                    Forest                 = 'contoso.com'
+                    ObjectClass            = 'pKIEnrollmentService'
+                    DistinguishedName      = 'CN=MyCA,CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
+                    IdentityReferenceSID   = 'S-1-1-0'  # DangerousPrincipal -> re-eval = 2
+                    IdentityReferenceClass = 'group'
+                }
+                Set-LS2RiskRating -Issues @($esc1, $esc5a)
+                # ESC1 disabled: 0 + TechBonus(1) + Disabled(-2) + SafePrincipal(0) = -1
+                # Cross: ESC5a DangerousPrincipal re-eval=2, cap=2 -> +2
+                # Final: -1 + 2 = 1 -> Informational
+                $esc1.RiskValue | Should -Be 1
+                $esc1.RiskName  | Should -Be 'Informational'
+            }
+
+            It 'disabled-template ESC5 cross-ESC is filtered to pKIEnrollmentService objectClass only' {
+                $esc1 = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC1'
+                    Enabled                = $false
+                    Forest                 = 'contoso.com'
+                    IdentityReferenceSID   = 'S-1-5-21-1234-5678-9012-512'
+                    IdentityReferenceClass = 'group'
+                }
+                $esc5a = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC5a'
+                    Forest                 = 'contoso.com'
+                    ObjectClass            = 'container'  # NOT pKIEnrollmentService -- should not contribute
+                    DistinguishedName      = 'CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
+                    IdentityReferenceSID   = 'S-1-1-0'
+                    IdentityReferenceClass = 'group'
+                }
+                Set-LS2RiskRating -Issues @($esc1, $esc5a)
+                # No cross-ESC bonus because ObjectClass is not pKIEnrollmentService
+                # ESC1 disabled: -1, clamped to 0
+                $esc1.RiskValue | Should -Be 0
+            }
+
+            It 'enabled ESC1 does NOT get ESC5 cross-ESC (OnlyWhenDisabled = $true)' {
+                $esc1 = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC1'
+                    Enabled                = $true  # enabled -- should NOT trigger OnlyWhenDisabled modifier
+                    Forest                 = 'contoso.com'
+                    IdentityReferenceSID   = 'S-1-5-21-1234-5678-9012-512'
+                    IdentityReferenceClass = 'group'
+                }
+                $esc5a = New-MockLS2Issue -Overrides @{
+                    Technique              = 'ESC5a'
+                    Forest                 = 'contoso.com'
+                    ObjectClass            = 'pKIEnrollmentService'
+                    DistinguishedName      = 'CN=MyCA,CN=Enrollment Services,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
+                    IdentityReferenceSID   = 'S-1-1-0'
+                    IdentityReferenceClass = 'group'
+                }
+                Set-LS2RiskRating -Issues @($esc1, $esc5a)
+                # ESC1 enabled: 0 + 1(TechBonus) + 1(enabled) + 0(SafePrincipal) = 2, no ESC5 cross
+                $esc1.RiskValue | Should -Be 2
+            }
+        }
+
+        # ------------------------------------------------------------------ #
+        #  RiskScoring audit trail
+        # ------------------------------------------------------------------ #
+        Context 'RiskScoring audit trail' {
+            It 'RiskScoring is populated after rating' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique  = 'Auditing'
+                    CAFullName = 'srv\CA'
+                    Forest     = 'contoso.com'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                $issue.RiskScoring | Should -Not -BeNullOrEmpty
+            }
+
+            It 'RiskScoring contains at least BaseScore entry' {
+                $issue = New-MockLS2Issue -Overrides @{
+                    Technique = 'ESC1'
+                    Enabled   = $true
+                    Forest    = 'contoso.com'
+                    IdentityReferenceSID   = 'S-1-5-21-1234-5678-9012-512'
+                    IdentityReferenceClass = 'group'
+                }
+                Set-LS2RiskRating -Issues @($issue)
+                $issue.RiskScoring | Where-Object { $_ -match 'BaseScore' } | Should -Not -BeNullOrEmpty
+            }
+        }
+
+        # ------------------------------------------------------------------ #
+        #  Multiple issues
+        # ------------------------------------------------------------------ #
+        Context 'Multiple issues in one call' {
+            It 'rates all issues - none should have null RiskValue after the call' {
+                $issues = @(
+                    (New-MockLS2Issue -Overrides @{ Technique = 'Auditing'; CAFullName = 'srv\CA'; Forest = 'contoso.com' }),
+                    (New-MockLS2Issue -Overrides @{ Technique = 'ESC11';    CAFullName = 'srv\CA'; Forest = 'contoso.com' })
+                )
+                Set-LS2RiskRating -Issues $issues
+                $issues | Where-Object { $null -eq $_.RiskValue } | Should -BeNullOrEmpty
+            }
+
+            It 'mutates issues in place (returns nothing)' {
+                $issue = New-MockLS2Issue -Overrides @{ Technique = 'Auditing'; CAFullName = 'srv\CA'; Forest = 'contoso.com' }
+                $result = Set-LS2RiskRating -Issues @($issue)
+                $result | Should -BeNullOrEmpty
+                $issue.RiskValue | Should -Not -BeNullOrEmpty
+            }
+        }
+    }
+}

--- a/Tests/Private/Set/Set-LinkedGroupOIDPolicy.Tests.ps1
+++ b/Tests/Private/Set/Set-LinkedGroupOIDPolicy.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-ManagerApproval.Tests.ps1
+++ b/Tests/Private/Set/Set-ManagerApproval.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-NoSecurityExtension.Tests.ps1
+++ b/Tests/Private/Set/Set-NoSecurityExtension.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-Owner.Tests.ps1
+++ b/Tests/Private/Set/Set-Owner.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-RequiresEnrollmentAgentSignature.Tests.ps1
+++ b/Tests/Private/Set/Set-RequiresEnrollmentAgentSignature.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-SANAllowed.Tests.ps1
+++ b/Tests/Private/Set/Set-SANAllowed.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Set/Set-TemplateEnabled.Tests.ps1
+++ b/Tests/Private/Set/Set-TemplateEnabled.Tests.ps1
@@ -1,10 +1,12 @@
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Test/Test-IsDangerousAce.Tests.ps1
+++ b/Tests/Private/Test/Test-IsDangerousAce.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 Describe 'Test-IsDangerousAce' -Tag 'Unit' {

--- a/Tests/Private/Test/Test-IsDangerousPrincipal.Tests.ps1
+++ b/Tests/Private/Test/Test-IsDangerousPrincipal.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 Describe 'Test-IsDangerousPrincipal' -Tag 'Unit' {

--- a/Tests/Private/Test/Test-IsLowPrivilegePrincipal.Tests.ps1
+++ b/Tests/Private/Test/Test-IsLowPrivilegePrincipal.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 Describe 'Test-IsLowPrivilegePrincipal' -Tag 'Unit' {

--- a/Tests/Private/Test/Test-IsStandardOwner.Tests.ps1
+++ b/Tests/Private/Test/Test-IsStandardOwner.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 Describe 'Test-IsStandardOwner' -Tag 'Unit' {

--- a/Tests/Private/Test/Test-IssueExists.Tests.ps1
+++ b/Tests/Private/Test/Test-IssueExists.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Test/Test-PowerShellEnvironment.Tests.ps1
+++ b/Tests/Private/Test/Test-PowerShellEnvironment.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot))
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot))
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 InModuleScope 'Locksmith2' {

--- a/Tests/Private/UI/Read-Choice.Tests.ps1
+++ b/Tests/Private/UI/Read-Choice.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 InModuleScope 'Locksmith2' {

--- a/Tests/Private/UI/Show-IssueReport.Tests.ps1
+++ b/Tests/Private/UI/Show-IssueReport.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 InModuleScope 'Locksmith2' {

--- a/Tests/Private/Utility/Add-ToIssueStore.Tests.ps1
+++ b/Tests/Private/Utility/Add-ToIssueStore.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Utility/Expand-IssueByGroup.Tests.ps1
+++ b/Tests/Private/Utility/Expand-IssueByGroup.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Utility/Get-AdcsObjectName.Tests.ps1
+++ b/Tests/Private/Utility/Get-AdcsObjectName.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot))
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot))
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Utility/Get-IssueCount.Tests.ps1
+++ b/Tests/Private/Utility/Get-IssueCount.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Private/Utility/Install-NeededModule.Tests.ps1
+++ b/Tests/Private/Utility/Install-NeededModule.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot -Parent) -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 Describe 'Install-NeededModule' -Tag 'Unit' {

--- a/Tests/Private/Utility/Repair-PowerShellEnvironment.Tests.ps1
+++ b/Tests/Private/Utility/Repair-PowerShellEnvironment.Tests.ps1
@@ -1,11 +1,13 @@
-﻿#requires -Version 5.1
+#requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot))
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path (Split-Path $PSScriptRoot))
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 InModuleScope 'Locksmith2' {

--- a/Tests/Public/Find-LS2RiskyPrincipal.Tests.ps1
+++ b/Tests/Public/Find-LS2RiskyPrincipal.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Public/Find-LS2VulnerableCA.Tests.ps1
+++ b/Tests/Public/Find-LS2VulnerableCA.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Public/Find-LS2VulnerableObject.Tests.ps1
+++ b/Tests/Public/Find-LS2VulnerableObject.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Public/Find-LS2VulnerableTemplate.Tests.ps1
+++ b/Tests/Public/Find-LS2VulnerableTemplate.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Public/Get-LS2Stores.Tests.ps1
+++ b/Tests/Public/Get-LS2Stores.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 InModuleScope 'Locksmith2' {

--- a/Tests/Public/Invoke-Locksmith2.Tests.ps1
+++ b/Tests/Public/Invoke-Locksmith2.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Public/New-LS2Dashboard.Tests.ps1
+++ b/Tests/Public/New-LS2Dashboard.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
     Import-Module (Join-Path $ModuleRoot 'Tests\Shared\TestHelpers.psm1') -Force -ErrorAction Stop
 }
 

--- a/Tests/Public/Set-LS2Credential.Tests.ps1
+++ b/Tests/Public/Set-LS2Credential.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 InModuleScope 'Locksmith2' {

--- a/Tests/Public/Set-LS2Forest.Tests.ps1
+++ b/Tests/Public/Set-LS2Forest.Tests.ps1
@@ -1,11 +1,13 @@
 #requires -Version 5.1
 BeforeDiscovery {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 BeforeAll {
     $ModuleRoot = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
-    Import-Module (Join-Path $ModuleRoot 'Locksmith2.psd1') -Force -ErrorAction Stop
+    $ls2Manifest = if ($env:LS2_MODULE_ROOT) { Join-Path $env:LS2_MODULE_ROOT 'Locksmith2.psd1' } else { Join-Path $ModuleRoot 'Locksmith2.psd1' }
+    Import-Module $ls2Manifest -Force -ErrorAction Stop
 }
 
 InModuleScope 'Locksmith2' {


### PR DESCRIPTION
## Summary
Add a per-issue risk scoring engine that assigns numeric scores and severity names to every detected issue, then surfaces them in the dashboard and scan output.

## Changes
- `Classes/LS2Issue.ps1`
  - Add `RiskValue`, `RiskName`, and `RiskScoring` properties
  - Preserve existing `EndpointURL` / `EndpointAttackVector` ESC8 metadata
- `Private/Data/ESCDefinitions.ps1`
  - Add `ESCScoringMetadata` block per technique: `BaseScore`, `TechniqueBonus`, `EnabledModifier`, `PrincipalRisk`, `ObjectClassBonus`, `EndpointBonuses`, `CrossESCModifiers`
- `Private/Set/Get-PrincipalRiskBonus.ps1`
  - New helper with additive principal risk model
  - Safe principal = 0, unsafe user = +1, unsafe group = +2, dangerous principal = +3
  - Dangerous principals do not receive the group modifier
- `Private/Set/Set-LS2RiskRating.ps1`
  - New post-scan function that computes and assigns risk ratings
- `Public/Invoke-Locksmith2.ps1`
  - Wire `Set-LS2RiskRating` into the scan pipeline
- `Public/New-LS2Dashboard.ps1`
  - Surface `RiskValue` / `RiskName` in dashboard output
- `Public/Find-LS2VulnerableCA.ps1`
  - Adjusted to support scoring flow
- `Docs/ADR/0003-escscoring-metadata-split-from-data-block.md`
  - Document design decision to split scoring metadata from the `data{}` block
- `Locksmith2.psd1`
  - Bump ModuleVersion to `2026.7.41800`
- Tests
  - Add `Set-LS2RiskRating.Tests.ps1`
  - Add `Get-PrincipalRiskBonus.Tests.ps1`
  - Expand `ESCDefinitions.Tests.ps1`
  - Update existing tests for new issue properties

## Merge Notes
Merged latest `main` into the feature branch and resolved conflicts in:
- `Locksmith2.psd1` (module version)
- `Public/Invoke-Locksmith2.ps1` (risk rating wiring)

## Verification
- [x] Unit tests added for scoring engine
- [x] Cross-ESC modifier tests added
- [x] Pester run in PS 5.1 and PS 7 (recommended before merge)