### PR TITLE
test(privilege): add unit tests for BA/DA/EA/LocalAdmin privilege checks

### DIFF
--- a/Tests/Private/Test/Test-IsBA.Tests.ps1
+++ b/Tests/Private/Test/Test-IsBA.Tests.ps1
@@ -1,0 +1,85 @@
+#requires -Version 5.1
+BeforeAll {
+    $PrivateTestRoot = Join-Path (Split-Path (Split-Path (Split-Path $PSScriptRoot))) 'Private\Test'
+    . ([scriptblock]::Create((Get-Content -Path (Join-Path $PrivateTestRoot 'Test-IsBA.ps1') -Raw)))
+
+    # Stubs for the module functions Test-IsBA depends on. Dot-sourcing the
+    # function alone does not bring these into scope, so define them here at the
+    # same scope and let Pester's Mock intercept them in individual tests.
+    function Convert-IdentityReferenceToSid { param([Parameter(ValueFromPipeline)]$InputObject) }
+    function New-AuthenticatedDirectoryEntry { param([string]$Path) }
+
+    # Returns the ParameterAttribute instances for a given parameter.
+    function Get-ParamAttr {
+        param($Command, $Name)
+        (Get-Command $Command).Parameters[$Name].Attributes |
+            Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
+    }
+}
+
+Describe 'Test-IsBA' -Tag 'Unit' {
+
+    Context 'Parameter contract' {
+
+        It 'should require -Credential' {
+            (Get-ParamAttr -Command 'Test-IsBA' -Name 'Credential').Mandatory | Should -Contain $true
+        }
+
+        It 'should require -RootDSE' {
+            (Get-ParamAttr -Command 'Test-IsBA' -Name 'RootDSE').Mandatory | Should -Contain $true
+        }
+
+        It 'should type -RootDSE as a DirectoryEntry' {
+            (Get-Command Test-IsBA).Parameters['RootDSE'].ParameterType.FullName |
+                Should -Be 'System.DirectoryServices.DirectoryEntry'
+        }
+
+        It 'should accept -IdentityReference from the pipeline' {
+            (Get-ParamAttr -Command 'Test-IsBA' -Name 'IdentityReference').ValueFromPipeline | Should -Contain $true
+        }
+
+        It 'should type -IdentityReference as an IdentityReference' {
+            (Get-Command Test-IsBA).Parameters['IdentityReference'].ParameterType.FullName |
+                Should -Be 'System.Security.Principal.IdentityReference'
+        }
+
+        It 'should declare a [bool] output type' {
+            (Get-Command Test-IsBA).OutputType.Name | Should -Match 'Boolean'
+        }
+    }
+
+    # The behavioral early-return paths bind a real DirectoryEntry to -RootDSE,
+    # which cannot be constructed off-Windows, so these are Windows-gated.
+    Context 'When the identity cannot be resolved to a SID' -Skip:(-not $IsWindows) {
+
+        It 'should fail safe to $false' {
+            Mock Convert-IdentityReferenceToSid { $null }
+
+            $cred    = [System.Management.Automation.PSCredential]::new(
+                'CONTOSO\test', (ConvertTo-SecureString 'x' -AsPlainText -Force))
+            $rootDSE = [System.DirectoryServices.DirectoryEntry]::new()
+            $sid     = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-21-1-2-3-1001')
+
+            $sid | Test-IsBA -Credential $cred -RootDSE $rootDSE -WarningAction SilentlyContinue |
+                Should -BeFalse
+        }
+    }
+
+    Context 'When the RootDSE path is unusable' -Skip:(-not $IsWindows) {
+
+        It 'should fail safe to $false when no server can be parsed from RootDSE' {
+            # SID resolves, but an empty DirectoryEntry has no LDAP:// path to parse.
+            Mock Convert-IdentityReferenceToSid {
+                [System.Security.Principal.SecurityIdentifier]::new('S-1-5-21-1-2-3-1001')
+            }
+
+            $cred    = [System.Management.Automation.PSCredential]::new(
+                'CONTOSO\test', (ConvertTo-SecureString 'x' -AsPlainText -Force))
+            $rootDSE = [System.DirectoryServices.DirectoryEntry]::new()
+            $sid     = [System.Security.Principal.SecurityIdentifier]::new('S-1-5-21-1-2-3-1001')
+
+            $sid | Test-IsBA -Credential $cred -RootDSE $rootDSE -WarningAction SilentlyContinue |
+                Should -BeFalse
+        }
+    }
+}

--- a/Tests/Private/Test/Test-IsDA.Tests.ps1
+++ b/Tests/Private/Test/Test-IsDA.Tests.ps1
@@ -1,0 +1,44 @@
+#requires -Version 5.1
+BeforeAll {
+    $PrivateTestRoot = Join-Path (Split-Path (Split-Path (Split-Path $PSScriptRoot))) 'Private\Test'
+    . ([scriptblock]::Create((Get-Content -Path (Join-Path $PrivateTestRoot 'Test-IsDA.ps1') -Raw)))
+}
+
+Describe 'Test-IsDA' -Tag 'Unit' {
+
+    Context 'Contract' {
+
+        It 'should return a [bool]' {
+            Test-IsDA -ErrorAction SilentlyContinue | Should -BeOfType [bool]
+        }
+
+        It 'should expose no parameters of its own' {
+            $explicit = (Get-Command Test-IsDA).Parameters.Keys |
+                Where-Object { $_ -notin [System.Management.Automation.Cmdlet]::CommonParameters }
+            $explicit | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'When the Windows identity API is unavailable' -Skip:($IsWindows) {
+
+        It 'should fail safe to $false' {
+            Test-IsDA -ErrorAction SilentlyContinue | Should -BeFalse
+        }
+
+        It 'should write a non-terminating error rather than throw' {
+            { Test-IsDA -ErrorAction SilentlyContinue } | Should -Not -Throw
+            Test-IsDA -ErrorVariable err -ErrorAction SilentlyContinue | Out-Null
+            $err | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'When running on Windows' -Tag 'Integration' -Skip:(-not $IsWindows) {
+
+        It 'should agree with the token for well-known RID 512' {
+            $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+            $expected = [bool]($identity.Groups | Where-Object { $_.Value -match '-512$' })
+
+            Test-IsDA | Should -Be $expected
+        }
+    }
+}

--- a/Tests/Private/Test/Test-IsEA.Tests.ps1
+++ b/Tests/Private/Test/Test-IsEA.Tests.ps1
@@ -1,0 +1,44 @@
+#requires -Version 5.1
+BeforeAll {
+    $PrivateTestRoot = Join-Path (Split-Path (Split-Path (Split-Path $PSScriptRoot))) 'Private\Test'
+    . ([scriptblock]::Create((Get-Content -Path (Join-Path $PrivateTestRoot 'Test-IsEA.ps1') -Raw)))
+}
+
+Describe 'Test-IsEA' -Tag 'Unit' {
+
+    Context 'Contract' {
+
+        It 'should return a [bool]' {
+            Test-IsEA -ErrorAction SilentlyContinue | Should -BeOfType [bool]
+        }
+
+        It 'should expose no parameters of its own' {
+            $explicit = (Get-Command Test-IsEA).Parameters.Keys |
+                Where-Object { $_ -notin [System.Management.Automation.Cmdlet]::CommonParameters }
+            $explicit | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'When the Windows identity API is unavailable' -Skip:($IsWindows) {
+
+        It 'should fail safe to $false' {
+            Test-IsEA -ErrorAction SilentlyContinue | Should -BeFalse
+        }
+
+        It 'should write a non-terminating error rather than throw' {
+            { Test-IsEA -ErrorAction SilentlyContinue } | Should -Not -Throw
+            Test-IsEA -ErrorVariable err -ErrorAction SilentlyContinue | Out-Null
+            $err | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'When running on Windows' -Tag 'Integration' -Skip:(-not $IsWindows) {
+
+        It 'should agree with the token for well-known RID 519' {
+            $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+            $expected = [bool]($identity.Groups | Where-Object { $_.Value -match '-519$' })
+
+            Test-IsEA | Should -Be $expected
+        }
+    }
+}

--- a/Tests/Private/Test/Test-IsLocalAdmin.Tests.ps1
+++ b/Tests/Private/Test/Test-IsLocalAdmin.Tests.ps1
@@ -1,0 +1,48 @@
+#requires -Version 5.1
+BeforeAll {
+    $PrivateTestRoot = Join-Path (Split-Path (Split-Path (Split-Path $PSScriptRoot))) 'Private\Test'
+    . ([scriptblock]::Create((Get-Content -Path (Join-Path $PrivateTestRoot 'Test-IsLocalAdmin.ps1') -Raw)))
+}
+
+Describe 'Test-IsLocalAdmin' -Tag 'Unit' {
+
+    Context 'Contract' {
+
+        It 'should return a [bool]' {
+            Test-IsLocalAdmin -WarningAction SilentlyContinue | Should -BeOfType [bool]
+        }
+
+        It 'should never throw, even when the identity check fails' {
+            { Test-IsLocalAdmin -WarningAction SilentlyContinue } | Should -Not -Throw
+        }
+
+        It 'should expose no parameters of its own' {
+            $explicit = (Get-Command Test-IsLocalAdmin).Parameters.Keys |
+                Where-Object { $_ -notin [System.Management.Automation.Cmdlet]::CommonParameters }
+            $explicit | Should -BeNullOrEmpty
+        }
+    }
+
+    Context 'When the Windows identity API is unavailable' -Skip:($IsWindows) {
+
+        It 'should fail safe to $false' {
+            Test-IsLocalAdmin -WarningAction SilentlyContinue | Should -BeFalse
+        }
+
+        It 'should warn the caller that elevation could not be determined' {
+            Test-IsLocalAdmin -WarningVariable warn -WarningAction SilentlyContinue | Out-Null
+            $warn | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    Context 'When running on Windows' -Tag 'Integration' -Skip:(-not $IsWindows) {
+
+        It 'should agree with the current principal Administrator role' {
+            $identity  = [Security.Principal.WindowsIdentity]::GetCurrent()
+            $principal = [Security.Principal.WindowsPrincipal]$identity
+            $expected  = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+
+            Test-IsLocalAdmin | Should -Be $expected
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Add unit test coverage for the four privilege-check helper functions used during scan initialization.

## Changes
- `Tests/Private/Test/Test-IsBA.Tests.ps1`
  - Parameter contract tests (mandatory `Credential`/`RootDSE`, pipeline `IdentityReference`)
  - Windows-gated SID/RootDSE fail-safe paths
- `Tests/Private/Test/Test-IsDA.Tests.ps1`
  - Contract tests + non-terminating error assertion on RID 512/519 token checks
- `Tests/Private/Test/Test-IsEA.Tests.ps1`
  - Same pattern as DA tests for enterprise admin checks
- `Tests/Private/Test/Test-IsLocalAdmin.Tests.ps1`
  - Contract tests + macOS-gated fail-safe (catch returns `$false`, warns)

## Platform Handling
- Windows-only behavior is gated with `-Skip:(-not $IsWindows)`
- Catch branches are exercised on macOS where `GetCurrent()` throws
- No production code changed

## Verification
- [x] Tests written for all four privilege check functions
- [ ] Pester run on Windows recommended (macOS blocked by `CimCmdlets` manifest requirement)