### PR TITLE
fix(tests): replace $IsWindows with PS 5.1-compatible platform check

### DIFF
--- a/Tests/Private/Test/Test-IsDA.Tests.ps1
+++ b/Tests/Private/Test/Test-IsDA.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'Test-IsDA' -Tag 'Unit' {
         }
     }
 
-    Context 'When the Windows identity API is unavailable' -Skip:($IsWindows) {
+    Context 'When the Windows identity API is unavailable' -Skip:($env:OS -eq 'Windows_NT') {
 
         It 'should fail safe to $false' {
             Test-IsDA -ErrorAction SilentlyContinue | Should -BeFalse
@@ -32,7 +32,7 @@ Describe 'Test-IsDA' -Tag 'Unit' {
         }
     }
 
-    Context 'When running on Windows' -Tag 'Integration' -Skip:(-not $IsWindows) {
+    Context 'When running on Windows' -Tag 'Integration' -Skip:($env:OS -ne 'Windows_NT') {
 
         It 'should agree with the token for well-known RID 512' {
             $identity = [Security.Principal.WindowsIdentity]::GetCurrent()

--- a/Tests/Private/Test/Test-IsEA.Tests.ps1
+++ b/Tests/Private/Test/Test-IsEA.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'Test-IsEA' -Tag 'Unit' {
         }
     }
 
-    Context 'When the Windows identity API is unavailable' -Skip:($IsWindows) {
+    Context 'When the Windows identity API is unavailable' -Skip:($env:OS -eq 'Windows_NT') {
 
         It 'should fail safe to $false' {
             Test-IsEA -ErrorAction SilentlyContinue | Should -BeFalse
@@ -32,7 +32,7 @@ Describe 'Test-IsEA' -Tag 'Unit' {
         }
     }
 
-    Context 'When running on Windows' -Tag 'Integration' -Skip:(-not $IsWindows) {
+    Context 'When running on Windows' -Tag 'Integration' -Skip:($env:OS -ne 'Windows_NT') {
 
         It 'should agree with the token for well-known RID 519' {
             $identity = [Security.Principal.WindowsIdentity]::GetCurrent()

--- a/Tests/Private/Test/Test-IsLocalAdmin.Tests.ps1
+++ b/Tests/Private/Test/Test-IsLocalAdmin.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'Test-IsLocalAdmin' -Tag 'Unit' {
         }
     }
 
-    Context 'When the Windows identity API is unavailable' -Skip:($IsWindows) {
+    Context 'When the Windows identity API is unavailable' -Skip:($env:OS -eq 'Windows_NT') {
 
         It 'should fail safe to $false' {
             Test-IsLocalAdmin -WarningAction SilentlyContinue | Should -BeFalse
@@ -35,7 +35,7 @@ Describe 'Test-IsLocalAdmin' -Tag 'Unit' {
         }
     }
 
-    Context 'When running on Windows' -Tag 'Integration' -Skip:(-not $IsWindows) {
+    Context 'When running on Windows' -Tag 'Integration' -Skip:($env:OS -ne 'Windows_NT') {
 
         It 'should agree with the current principal Administrator role' {
             $identity  = [Security.Principal.WindowsIdentity]::GetCurrent()


### PR DESCRIPTION
## Summary

Replaces the PowerShell 6+ automatic variable `$IsWindows` with a check that works in both Windows PowerShell 5.1 and PowerShell 7.x.

## Problem

The Pester `-Skip` expressions in `Test-IsDA.Tests.ps1`, `Test-IsEA.Tests.ps1`, and `Test-IsLocalAdmin.Tests.ps1` used `$IsWindows` to gate platform-specific contexts. `$IsWindows` does not exist in PS 5.1, so it evaluated to `$null` and the skip logic inverted:

- The "Windows identity API unavailable" error-path contexts ran on Windows.
- The real Windows integration contexts were skipped.

Because the current CI/test environment runs as a privileged user (DA/EA/local admin), the error-path tests expected `$false` but got `$true`, causing 6 failures.

## Changes

- `Tests/Private/Test/Test-IsDA.Tests.ps1`
- `Tests/Private/Test/Test-IsEA.Tests.ps1`
- `Tests/Private/Test/Test-IsLocalAdmin.Tests.ps1`

`-Skip:($IsWindows)` → `-Skip:($env:OS -eq 'Windows_NT')`
`-Skip:(-not $IsWindows)` → `-Skip:($env:OS -ne 'Windows_NT')`

## Verification

- **powershell.exe (5.1):** 2145 passed, 0 failed, 31 skipped
- **pwsh (7.x):** 2147 passed, 0 failed, 29 skipped

## Related

- Keeps the project compatible with the stated PS 5.1+ support.
- No production code changes.