### PR TITLE
refactor(ui): remove LS2 prefix from private Show-* helpers and add Invoke-Locksmith2 aliases

### DIFF
--- a/Private/UI/Show-ConnectionContext.ps1
+++ b/Private/UI/Show-ConnectionContext.ps1
@@ -1,4 +1,4 @@
-function Show-LS2ConnectionContext {
+function Show-ConnectionContext {
     <#
         .SYNOPSIS
         Displays the resolved connection context and prompts for confirmation.
@@ -20,13 +20,13 @@ function Show-LS2ConnectionContext {
 
         .EXAMPLE
         $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-        Show-LS2ConnectionContext -Context $ctx
+        Show-ConnectionContext -Context $ctx
 
         Displays the connection context and prompts the user to proceed.
 
         .EXAMPLE
         $ctx = @{ Forest = 'contoso.com'; Credential = $cred; Method = 'ExplicitCredential' }
-        Show-LS2ConnectionContext -Context $ctx -Force
+        Show-ConnectionContext -Context $ctx -Force
 
         Displays the connection context and skips the confirmation prompt.
 

--- a/Private/UI/Show-ConnectionDiagnostics.ps1
+++ b/Private/UI/Show-ConnectionDiagnostics.ps1
@@ -1,4 +1,4 @@
-function Show-LS2ConnectionDiagnostics {
+function Show-ConnectionDiagnostics {
     <#
         .SYNOPSIS
         Displays detailed connection diagnostics for Active Directory LDAP connectivity.
@@ -23,11 +23,11 @@ function Show-LS2ConnectionDiagnostics {
         Used to capture the specific bind error.
 
         .EXAMPLE
-        Show-LS2ConnectionDiagnostics -Forest 'corp.contoso.com'
+        Show-ConnectionDiagnostics -Forest 'corp.contoso.com'
         Displays diagnostics for the target forest using the current identity.
 
         .EXAMPLE
-        Show-LS2ConnectionDiagnostics -Forest 'corp.contoso.com' -Credential $cred -RootDSE $rootDSE
+        Show-ConnectionDiagnostics -Forest 'corp.contoso.com' -Credential $cred -RootDSE $rootDSE
         Displays diagnostics including credential info and the original bind error.
 
         .OUTPUTS

--- a/Private/UI/Show-PrivilegeContext.ps1
+++ b/Private/UI/Show-PrivilegeContext.ps1
@@ -1,4 +1,4 @@
-function Show-LS2PrivilegeContext {
+function Show-PrivilegeContext {
     <#
         .SYNOPSIS
         Displays the current principal's privileges in the target forest.
@@ -24,7 +24,7 @@ function Show-LS2PrivilegeContext {
 
         .EXAMPLE
         $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-        Show-LS2PrivilegeContext -Context $ctx
+        Show-PrivilegeContext -Context $ctx
 
         Displays the current principal's privilege status. Builtin Administrator
         status is shown as Unknown because no credential was supplied.
@@ -33,7 +33,7 @@ function Show-LS2PrivilegeContext {
         $cred = Get-Credential -Message 'Domain admin credential'
         $rootDSE = Get-RootDSE -Forest 'contoso.com' -Credential $cred
         $ctx = @{ Forest = 'contoso.com'; Credential = $cred; Method = 'ExplicitCredential' }
-        Show-LS2PrivilegeContext -Context $ctx -RootDSE $rootDSE
+        Show-PrivilegeContext -Context $ctx -RootDSE $rootDSE
 
         Displays the current principal's privilege status, including Builtin
         Administrator membership in the target forest.

--- a/Public/Invoke-Locksmith2.ps1
+++ b/Public/Invoke-Locksmith2.ps1
@@ -176,7 +176,7 @@ function Invoke-Locksmith2 {
 
     Write-Verbose "Connection context resolved: Forest=$($ctx.Forest), Method=$($ctx.Method)"
 
-    $shouldProceed = Show-LS2ConnectionContext -Context $ctx -Force:$Force
+    $shouldProceed = Show-ConnectionContext -Context $ctx -Force:$Force
     if (-not $shouldProceed) {
         return
     }
@@ -196,7 +196,7 @@ function Invoke-Locksmith2 {
         return
     }
 
-    $shouldProceed = Show-LS2PrivilegeContext -Context $ctx -RootDSE $script:RootDSE -Force:$Force
+    $shouldProceed = Show-PrivilegeContext -Context $ctx -RootDSE $script:RootDSE -Force:$Force
     if (-not $shouldProceed) {
         return
     }

--- a/Public/Invoke-Locksmith2.ps1
+++ b/Public/Invoke-Locksmith2.ps1
@@ -60,6 +60,9 @@ function Invoke-Locksmith2 {
         Use in non-interactive or automated contexts where [System.Environment]::UserInteractive
         would otherwise trigger a prompt.
 
+        .ALIAS
+        Invoke-LS2, Locksmith2, Start-Locksmith2, Start-LS2
+
         .INPUTS
         None. This function does not accept pipeline input.
 
@@ -131,6 +134,7 @@ function Invoke-Locksmith2 {
           complete audit filter data and for automatic execution of fix/revert scripts.
     #>
     [CmdletBinding()]
+    [Alias('Invoke-LS2', 'Locksmith2', 'Start-Locksmith2', 'Start-LS2')]
     param (
         [string]$Forest,
         [System.Management.Automation.PSCredential]$Credential,

--- a/Tests/Private/UI/Show-ConnectionContext.Tests.ps1
+++ b/Tests/Private/UI/Show-ConnectionContext.Tests.ps1
@@ -11,7 +11,7 @@ BeforeAll {
 }
 
 InModuleScope 'Locksmith2' {
-    Describe 'Show-LS2ConnectionContext' -Tag 'Unit' {
+    Describe 'Show-ConnectionContext' -Tag 'Unit' {
         BeforeEach {
             Mock 'Write-Host' { }
             Mock 'Write-Verbose' { }
@@ -20,18 +20,18 @@ InModuleScope 'Locksmith2' {
 
         Context 'Parameter contract' {
             It 'should require -Context' {
-                $attr = (Get-Command 'Show-LS2ConnectionContext').Parameters['Context'].Attributes |
+                $attr = (Get-Command 'Show-ConnectionContext').Parameters['Context'].Attributes |
                     Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
                 $attr.Mandatory | Should -Contain $true
             }
 
             It 'should type -Context as a hashtable' {
-                (Get-Command 'Show-LS2ConnectionContext').Parameters['Context'].ParameterType.FullName |
+                (Get-Command 'Show-ConnectionContext').Parameters['Context'].ParameterType.FullName |
                     Should -Be 'System.Collections.Hashtable'
             }
 
             It 'should accept -Force as a switch' {
-                (Get-Command 'Show-LS2ConnectionContext').Parameters['Force'].ParameterType.FullName |
+                (Get-Command 'Show-ConnectionContext').Parameters['Force'].ParameterType.FullName |
                     Should -Be 'System.Management.Automation.SwitchParameter'
             }
         }
@@ -39,14 +39,14 @@ InModuleScope 'Locksmith2' {
         Context 'When displaying the connection context' {
             It 'should print the forest' {
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2ConnectionContext -Context $ctx -Force
+                Show-ConnectionContext -Context $ctx -Force
                 Should -Invoke 'Write-Host' -ParameterFilter { $Object -eq '  Forest   : contoso.com' }
             }
 
             It 'should print the user when no credential is supplied' {
                 Mock 'Test-IsInteractiveSession' { $true }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2ConnectionContext -Context $ctx -Force
+                Show-ConnectionContext -Context $ctx -Force
                 Should -Invoke 'Write-Host' -ParameterFilter { $Object -like '*User     :*' }
             }
 
@@ -54,19 +54,19 @@ InModuleScope 'Locksmith2' {
                 $cred = [System.Management.Automation.PSCredential]::new(
                     'CONTOSO\admin', (ConvertTo-SecureString 'x' -AsPlainText -Force))
                 $ctx = @{ Forest = 'contoso.com'; Credential = $cred; Method = 'ExplicitCredential' }
-                Show-LS2ConnectionContext -Context $ctx -Force
+                Show-ConnectionContext -Context $ctx -Force
                 Should -Invoke 'Write-Host' -ParameterFilter { $Object -like '*CONTOSO\admin*' }
             }
 
             It 'should print the computer' {
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2ConnectionContext -Context $ctx -Force
+                Show-ConnectionContext -Context $ctx -Force
                 Should -Invoke 'Write-Host' -ParameterFilter { $Object -like '*Computer :*' }
             }
 
             It 'should print the method' {
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2ConnectionContext -Context $ctx -Force
+                Show-ConnectionContext -Context $ctx -Force
                 Should -Invoke 'Write-Host' -ParameterFilter { $Object -eq '  Method   : DomainUser' }
             }
         }
@@ -75,21 +75,21 @@ InModuleScope 'Locksmith2' {
             It 'should prompt when -Force is not specified' {
                 Mock 'Test-IsInteractiveSession' { $true }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2ConnectionContext -Context $ctx
+                Show-ConnectionContext -Context $ctx
                 Should -Invoke 'Read-Choice' -Times 1
             }
 
             It 'should not prompt when -Force is specified' {
                 Mock 'Test-IsInteractiveSession' { $true }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2ConnectionContext -Context $ctx -Force
+                Show-ConnectionContext -Context $ctx -Force
                 Should -Invoke 'Read-Choice' -Times 0
             }
 
             It 'should not prompt when not interactive' {
                 Mock 'Test-IsInteractiveSession' { $false }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2ConnectionContext -Context $ctx
+                Show-ConnectionContext -Context $ctx
                 Should -Invoke 'Read-Choice' -Times 0
             }
 
@@ -97,7 +97,7 @@ InModuleScope 'Locksmith2' {
                 Mock 'Test-IsInteractiveSession' { $true }
                 Mock 'Read-Choice' { 'n' }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                $result = Show-LS2ConnectionContext -Context $ctx
+                $result = Show-ConnectionContext -Context $ctx
                 $result | Should -BeFalse
             }
 
@@ -105,13 +105,13 @@ InModuleScope 'Locksmith2' {
                 Mock 'Test-IsInteractiveSession' { $true }
                 Mock 'Read-Choice' { 'y' }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                $result = Show-LS2ConnectionContext -Context $ctx
+                $result = Show-ConnectionContext -Context $ctx
                 $result | Should -BeTrue
             }
 
             It 'should return $true when -Force is specified' {
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                $result = Show-LS2ConnectionContext -Context $ctx -Force
+                $result = Show-ConnectionContext -Context $ctx -Force
                 $result | Should -BeTrue
             }
         }

--- a/Tests/Private/UI/Show-PrivilegeContext.Tests.ps1
+++ b/Tests/Private/UI/Show-PrivilegeContext.Tests.ps1
@@ -11,7 +11,7 @@ BeforeAll {
 }
 
 InModuleScope 'Locksmith2' {
-    Describe 'Show-LS2PrivilegeContext' -Tag 'Unit' {
+    Describe 'Show-PrivilegeContext' -Tag 'Unit' {
         BeforeEach {
             Mock 'Write-Host' { }
             Mock 'Write-Verbose' { }
@@ -26,48 +26,48 @@ InModuleScope 'Locksmith2' {
 
         Context 'Parameter contract' {
             It 'should require -Context' {
-                $attr = (Get-Command 'Show-LS2PrivilegeContext').Parameters['Context'].Attributes |
+                $attr = (Get-Command 'Show-PrivilegeContext').Parameters['Context'].Attributes |
                     Where-Object { $_ -is [System.Management.Automation.ParameterAttribute] }
                 $attr.Mandatory | Should -Contain $true
             }
 
             It 'should type -Context as a hashtable' {
-                (Get-Command 'Show-LS2PrivilegeContext').Parameters['Context'].ParameterType.FullName |
+                (Get-Command 'Show-PrivilegeContext').Parameters['Context'].ParameterType.FullName |
                     Should -Be 'System.Collections.Hashtable'
             }
 
             It 'should accept -Force as a switch' {
-                (Get-Command 'Show-LS2PrivilegeContext').Parameters['Force'].ParameterType.FullName |
+                (Get-Command 'Show-PrivilegeContext').Parameters['Force'].ParameterType.FullName |
                     Should -Be 'System.Management.Automation.SwitchParameter'
             }
 
             It 'should declare a [bool] output type' {
-                (Get-Command 'Show-LS2PrivilegeContext').OutputType.Name | Should -Match 'Boolean'
+                (Get-Command 'Show-PrivilegeContext').OutputType.Name | Should -Match 'Boolean'
             }
         }
 
         Context 'When displaying privilege status' {
             It 'should print DA status' {
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2PrivilegeContext -Context $ctx
+                Show-PrivilegeContext -Context $ctx
                 Should -Invoke 'Write-Host' -ParameterFilter { $Object -like '*Domain Admin*' }
             }
 
             It 'should print EA status' {
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2PrivilegeContext -Context $ctx
+                Show-PrivilegeContext -Context $ctx
                 Should -Invoke 'Write-Host' -ParameterFilter { $Object -like '*Enterprise Admin*' }
             }
 
             It 'should print BA status' {
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2PrivilegeContext -Context $ctx
+                Show-PrivilegeContext -Context $ctx
                 Should -Invoke 'Write-Host' -ParameterFilter { $Object -like '*Builtin Admin*' }
             }
 
             It 'should print local admin status' {
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2PrivilegeContext -Context $ctx
+                Show-PrivilegeContext -Context $ctx
                 Should -Invoke 'Write-Host' -ParameterFilter { $Object -like '*Local Admin*' }
             }
 
@@ -76,21 +76,21 @@ InModuleScope 'Locksmith2' {
                     'CONTOSO\admin', (ConvertTo-SecureString 'x' -AsPlainText -Force))
                 $ctx = @{ Forest = 'contoso.com'; Credential = $cred; Method = 'ExplicitCredential' }
                 $rootDSE = [System.DirectoryServices.DirectoryEntry]::new()
-                Show-LS2PrivilegeContext -Context $ctx -RootDSE $rootDSE
+                Show-PrivilegeContext -Context $ctx -RootDSE $rootDSE
                 Should -Invoke 'Test-IsBA' -ParameterFilter { $Credential -eq $cred -and $RootDSE -eq $rootDSE }
             }
 
             It 'should call Test-IsBA with a null credential when none is supplied' {
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
                 $rootDSE = [System.DirectoryServices.DirectoryEntry]::new()
-                Show-LS2PrivilegeContext -Context $ctx -RootDSE $rootDSE
+                Show-PrivilegeContext -Context $ctx -RootDSE $rootDSE
                 Should -Invoke 'Test-IsBA' -ParameterFilter { $Credential -eq $null -and $RootDSE -eq $rootDSE }
             }
 
             It 'should print a transient checking message' {
                 Mock 'Test-IsInteractiveSession' { $true }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2PrivilegeContext -Context $ctx
+                Show-PrivilegeContext -Context $ctx
                 Should -Invoke 'Write-Host' -ParameterFilter { $Object -like '*Checking*privileges*contoso.com*' }
             }
         }
@@ -99,21 +99,21 @@ InModuleScope 'Locksmith2' {
             It 'should prompt when interactive and -Force is not specified' {
                 Mock 'Test-IsInteractiveSession' { $true }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2PrivilegeContext -Context $ctx
+                Show-PrivilegeContext -Context $ctx
                 Should -Invoke 'Read-Choice' -Times 1
             }
 
             It 'should not prompt when -Force is specified' {
                 Mock 'Test-IsInteractiveSession' { $true }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2PrivilegeContext -Context $ctx -Force
+                Show-PrivilegeContext -Context $ctx -Force
                 Should -Invoke 'Read-Choice' -Times 0
             }
 
             It 'should not prompt when not interactive' {
                 Mock 'Test-IsInteractiveSession' { $false }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2PrivilegeContext -Context $ctx
+                Show-PrivilegeContext -Context $ctx
                 Should -Invoke 'Read-Choice' -Times 0
             }
 
@@ -121,7 +121,7 @@ InModuleScope 'Locksmith2' {
                 Mock 'Test-IsInteractiveSession' { $true }
                 Mock 'Read-Choice' { 'n' }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                $result = Show-LS2PrivilegeContext -Context $ctx
+                $result = Show-PrivilegeContext -Context $ctx
                 $result | Should -BeFalse
             }
 
@@ -129,14 +129,14 @@ InModuleScope 'Locksmith2' {
                 Mock 'Test-IsInteractiveSession' { $true }
                 Mock 'Read-Choice' { 'y' }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                $result = Show-LS2PrivilegeContext -Context $ctx
+                $result = Show-PrivilegeContext -Context $ctx
                 $result | Should -BeTrue
             }
 
             It 'should return $true when -Force is specified' {
                 Mock 'Test-IsInteractiveSession' { $true }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                $result = Show-LS2PrivilegeContext -Context $ctx -Force
+                $result = Show-PrivilegeContext -Context $ctx -Force
                 $result | Should -BeTrue
             }
         }
@@ -145,14 +145,14 @@ InModuleScope 'Locksmith2' {
             It 'should indicate DA privileges' {
                 Mock 'Test-IsDA' { $true }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2PrivilegeContext -Context $ctx
+                Show-PrivilegeContext -Context $ctx
                 Should -Invoke 'Write-Host' -ParameterFilter { $Object -like '*Yes*' -and $Object -like '*Domain Admin*' }
             }
 
             It 'should indicate EA privileges' {
                 Mock 'Test-IsEA' { $true }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2PrivilegeContext -Context $ctx
+                Show-PrivilegeContext -Context $ctx
                 Should -Invoke 'Write-Host' -ParameterFilter { $Object -like '*Yes*' -and $Object -like '*Enterprise Admin*' }
             }
 
@@ -162,7 +162,7 @@ InModuleScope 'Locksmith2' {
                 Mock 'Test-IsBA' { $true }
                 $rootDSE = [System.DirectoryServices.DirectoryEntry]::new()
                 $ctx = @{ Forest = 'contoso.com'; Credential = $cred; Method = 'ExplicitCredential' }
-                Show-LS2PrivilegeContext -Context $ctx -RootDSE $rootDSE
+                Show-PrivilegeContext -Context $ctx -RootDSE $rootDSE
                 Should -Invoke 'Write-Host' -ParameterFilter { $Object -like '*Builtin Admin*' }
                 Should -Invoke 'Write-Host' -ParameterFilter { $Object -like '*Yes*' }
             }
@@ -170,7 +170,7 @@ InModuleScope 'Locksmith2' {
             It 'should indicate local admin privileges' {
                 Mock 'Test-IsLocalAdmin' { $true }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2PrivilegeContext -Context $ctx
+                Show-PrivilegeContext -Context $ctx
                 Should -Invoke 'Write-Host' -ParameterFilter { $Object -like '*Yes*' -and $Object -like '*Local Admin*' }
             }
         }
@@ -189,7 +189,7 @@ InModuleScope 'Locksmith2' {
                 ); $false }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $cred; Method = 'ExplicitCredential' }
                 $rootDSE = [System.DirectoryServices.DirectoryEntry]::new()
-                Show-LS2PrivilegeContext -Context $ctx -RootDSE $rootDSE -ErrorAction SilentlyContinue
+                Show-PrivilegeContext -Context $ctx -RootDSE $rootDSE -ErrorAction SilentlyContinue
                 Should -Invoke 'Write-Host' -ParameterFilter { $Object -like '*Builtin Admin*' -and $Object -like '*Unknown*' }
                 Should -Invoke 'Write-Warning' -Times 1
             }
@@ -205,7 +205,7 @@ InModuleScope 'Locksmith2' {
                 ); $false }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
                 $rootDSE = [System.DirectoryServices.DirectoryEntry]::new()
-                Show-LS2PrivilegeContext -Context $ctx -RootDSE $rootDSE -ErrorAction SilentlyContinue
+                Show-PrivilegeContext -Context $ctx -RootDSE $rootDSE -ErrorAction SilentlyContinue
                 Should -Invoke 'Write-Host' -ParameterFilter { $Object -like '*Builtin Admin*' -and $Object -like '*Unknown*' }
                 Should -Invoke 'Write-Warning' -Times 1
             }
@@ -215,21 +215,21 @@ InModuleScope 'Locksmith2' {
             It 'should not print the privilege context block' {
                 Mock 'Test-IsInteractiveSession' { $false }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2PrivilegeContext -Context $ctx
+                Show-PrivilegeContext -Context $ctx
                 Should -Invoke 'Write-Host' -Times 0
             }
 
             It 'should still write verbose privilege lines' {
                 Mock 'Test-IsInteractiveSession' { $false }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                Show-LS2PrivilegeContext -Context $ctx
+                Show-PrivilegeContext -Context $ctx
                 Should -Invoke 'Write-Verbose' -Times 1 -Exactly:$false
             }
 
             It 'should return $true without prompting' {
                 Mock 'Test-IsInteractiveSession' { $false }
                 $ctx = @{ Forest = 'contoso.com'; Credential = $null; Method = 'DomainUser' }
-                $result = Show-LS2PrivilegeContext -Context $ctx
+                $result = Show-PrivilegeContext -Context $ctx
                 $result | Should -BeTrue
             }
         }

--- a/Tests/Public/Invoke-Locksmith2.Tests.ps1
+++ b/Tests/Public/Invoke-Locksmith2.Tests.ps1
@@ -29,8 +29,8 @@ InModuleScope 'Locksmith2' {
             Mock 'Get-FlattenedIssues' { @($script:mockIssue) }
             Mock 'Get-IssueCount' { 0 }
             Mock 'Show-IssueReport' { }
-            Mock 'Show-LS2ConnectionContext' { $true }
-            Mock 'Show-LS2PrivilegeContext' { $true }
+            Mock 'Show-ConnectionContext' { $true }
+            Mock 'Show-PrivilegeContext' { $true }
             Mock 'Test-PowerShellEnvironment' { [PSCustomObject]@{} }
             Mock 'Repair-PowerShellEnvironment' { }
             Mock 'Expand-IssueByGroup' { $_ }
@@ -95,46 +95,46 @@ InModuleScope 'Locksmith2' {
             Should -Invoke 'Expand-IssueByGroup' -Times 1
         }
 
-        It 'should call Show-LS2ConnectionContext with the resolved context' {
+        It 'should call Show-ConnectionContext with the resolved context' {
             Invoke-Locksmith2 -Forest 'contoso.com' | Out-Null
-            Should -Invoke 'Show-LS2ConnectionContext' -Times 1 -ParameterFilter {
+            Should -Invoke 'Show-ConnectionContext' -Times 1 -ParameterFilter {
                 $Context.Forest -eq 'contoso.com'
             }
         }
 
-        It 'should not call Show-LS2PrivilegeContext when Initialize-LS2Scan returns false' {
+        It 'should not call Show-PrivilegeContext when Initialize-LS2Scan returns false' {
             Mock 'Initialize-LS2Scan' { $false }
             Mock 'Write-Error' { }
             Invoke-Locksmith2 | Out-Null
-            Should -Invoke 'Show-LS2PrivilegeContext' -Times 0
+            Should -Invoke 'Show-PrivilegeContext' -Times 0
         }
 
-        It 'should call Show-LS2PrivilegeContext after Initialize-LS2Scan succeeds' {
+        It 'should call Show-PrivilegeContext after Initialize-LS2Scan succeeds' {
             $script:RootDSE = [System.DirectoryServices.DirectoryEntry]::new()
             Invoke-Locksmith2 | Out-Null
-            Should -Invoke 'Show-LS2PrivilegeContext' -Times 1
+            Should -Invoke 'Show-PrivilegeContext' -Times 1
         }
 
-        It 'should pass RootDSE to Show-LS2PrivilegeContext' {
+        It 'should pass RootDSE to Show-PrivilegeContext' {
             $script:RootDSE = [System.DirectoryServices.DirectoryEntry]::new()
             Invoke-Locksmith2 | Out-Null
-            Should -Invoke 'Show-LS2PrivilegeContext' -Times 1 -ParameterFilter {
+            Should -Invoke 'Show-PrivilegeContext' -Times 1 -ParameterFilter {
                 $RootDSE -ne $null
             }
         }
 
-        It 'should return early when Show-LS2PrivilegeContext returns false' {
-            Mock 'Show-LS2PrivilegeContext' { $false }
+        It 'should return early when Show-PrivilegeContext returns false' {
+            Mock 'Show-PrivilegeContext' { $false }
             $script:RootDSE = [System.DirectoryServices.DirectoryEntry]::new()
             Invoke-Locksmith2 | Out-Null
-            Should -Invoke 'Show-LS2PrivilegeContext' -Times 1
+            Should -Invoke 'Show-PrivilegeContext' -Times 1
         }
 
-        It 'should return early when Show-LS2ConnectionContext returns false' {
-            Mock 'Show-LS2ConnectionContext' { $false }
+        It 'should return early when Show-ConnectionContext returns false' {
+            Mock 'Show-ConnectionContext' { $false }
             Invoke-Locksmith2 | Out-Null
             Should -Invoke 'Initialize-LS2Scan' -Times 0
-            Should -Invoke 'Show-LS2PrivilegeContext' -Times 0
+            Should -Invoke 'Show-PrivilegeContext' -Times 0
         }
     }
 }

--- a/Tests/Public/Invoke-Locksmith2.Tests.ps1
+++ b/Tests/Public/Invoke-Locksmith2.Tests.ps1
@@ -41,6 +41,22 @@ InModuleScope 'Locksmith2' {
             Should -Invoke 'Initialize-LS2Scan' -Times 1
         }
 
+        It 'should expose Invoke-LS2 alias' {
+            (Get-Alias Invoke-LS2).ResolvedCommandName | Should -Be 'Invoke-Locksmith2'
+        }
+
+        It 'should expose Locksmith2 alias' {
+            (Get-Alias Locksmith2).ResolvedCommandName | Should -Be 'Invoke-Locksmith2'
+        }
+
+        It 'should expose Start-Locksmith2 alias' {
+            (Get-Alias Start-Locksmith2).ResolvedCommandName | Should -Be 'Invoke-Locksmith2'
+        }
+
+        It 'should expose Start-LS2 alias' {
+            (Get-Alias Start-LS2).ResolvedCommandName | Should -Be 'Invoke-Locksmith2'
+        }
+
         It 'should call Test-PowerShellEnvironment when -SkipPowerShellCheck is not specified' {
             Invoke-Locksmith2 | Out-Null
             Should -Invoke 'Test-PowerShellEnvironment' -Times 1


### PR DESCRIPTION
## Summary

Removes the redundant `LS2` prefix from private UI helper functions and adds convenient aliases for `Invoke-Locksmith2`.

## What's Changed

### UI Helper Rename
- Renamed `Show-LS2ConnectionContext` → `Show-ConnectionContext`
- Renamed `Show-LS2ConnectionDiagnostics` → `Show-ConnectionDiagnostics`
- Renamed `Show-LS2PrivilegeContext` → `Show-PrivilegeContext`
- Updated all call sites in `Invoke-Locksmith2`
- Updated test files and mock references to match

### Invoke-Locksmith2 Aliases
- Added aliases: `Invoke-LS2`, `Locksmith2`, `Start-Locksmith2`, `Start-LS2`
- Documented aliases in comment-based help `.ALIAS` section
- Added tests verifying each alias resolves to `Invoke-Locksmith2`

## Testing

- Full Pester suite passes in PS 5.1: 2205 passed, 0 failed.
- Full Pester suite passes in PS 7: 2207 passed, 0 failed.
- Targeted Invoke-Locksmith2 tests pass: 21 passed, 0 failed.

## Files Changed

- `Private/UI/Show-ConnectionContext.ps1` (renamed)
- `Private/UI/Show-ConnectionDiagnostics.ps1` (renamed)
- `Private/UI/Show-PrivilegeContext.ps1` (renamed)
- `Tests/Private/UI/Show-ConnectionContext.Tests.ps1` (renamed)
- `Tests/Private/UI/Show-PrivilegeContext.Tests.ps1` (renamed)
- `Public/Invoke-Locksmith2.ps1`
- `Tests/Public/Invoke-Locksmith2.Tests.ps1`