### PR TITLE
feat(invoke): restore -Scans parameter from LS1 with coarse-name expansion

### DIFF
--- a/Locksmith2.psd1
+++ b/Locksmith2.psd1
@@ -8,7 +8,7 @@
     Description='An AD CS toolkit for AD Admins, Defensive Security Professionals, and Filthy Red Teamers'
     FunctionsToExport=@('*')
     GUID='e32f7d0d-2b10-4db2-b776-a193958e3d69'
-    ModuleVersion='2026.7.51027'
+    ModuleVersion='2026.7.51145'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{

--- a/Private/Initialize/Initialize-LS2Scan.ps1
+++ b/Private/Initialize/Initialize-LS2Scan.ps1
@@ -32,6 +32,11 @@
         Forces a fresh vulnerability scan even if IssueStore is already populated.
         Clears the IssueStore and rescans all AD CS configurations.
 
+        .PARAMETER Scans
+        Array of granular technique names to run. If not specified, all supported
+        techniques are scanned. This parameter is typically supplied by Invoke-Locksmith2
+        after resolving coarse names like 'ESC3' to 'ESC3c1', 'ESC3c2'.
+
         .OUTPUTS
         System.Boolean
         Returns $true if initialization succeeded, $false if it failed.
@@ -58,7 +63,10 @@
         [PSCredential]$Credential,
 
         [Parameter()]
-        [switch]$Rescan
+        [switch]$Rescan,
+
+        [Parameter()]
+        [string[]]$Scans
     )
 
     #requires -Version 5.1
@@ -105,6 +113,44 @@
         Write-Verbose "Rescan specified. Clearing AdcsObjectStore and IssueStore..."
         $script:AdcsObjectStore = @{}
         $script:IssueStore = @{}
+    }
+
+    # Resolve coarse LS1-style names and aliases to granular LS2 technique names
+    $scanMap = @{
+        'ESC3'  = @('ESC3c1', 'ESC3c2')
+        'ESC4'  = @('ESC4a', 'ESC4o')
+        'ESC5'  = @('ESC5a', 'ESC5o')
+        'ESC7'  = @('ESC7a', 'ESC7m')
+        'EKUwu' = @('ESC15')
+    }
+
+    if ($Scans) {
+        $resolvedScans = @(
+            foreach ($scan in $Scans) {
+                if ($scanMap.ContainsKey($scan)) {
+                    $scanMap[$scan]
+                } else {
+                    $scan
+                }
+            }
+        ) | Select-Object -Unique
+    } else {
+        $resolvedScans = $Scans
+    }
+
+    # Determine which techniques to scan; default to the full supported set
+    $allTemplateTechniques = @('ESC1', 'ESC2', 'ESC3c1', 'ESC3c2', 'ESC9', 'ESC4a', 'ESC4o', 'ESC13', 'ESC15', 'SchemaV1')
+    $allCATechniques       = @('ESC6', 'ESC7a', 'ESC7m', 'ESC8', 'ESC11', 'ESC16', 'Auditing')
+    $allObjectTechniques   = @('ESC5a', 'ESC5o')
+
+    if ($resolvedScans) {
+        $templateTechniques = @($allTemplateTechniques | Where-Object { $_ -in $resolvedScans })
+        $caTechniques       = @($allCATechniques | Where-Object { $_ -in $resolvedScans })
+        $objectTechniques   = @($allObjectTechniques | Where-Object { $_ -in $resolvedScans })
+    } else {
+        $templateTechniques = $allTemplateTechniques
+        $caTechniques       = $allCATechniques
+        $objectTechniques   = $allObjectTechniques
     }
 
     $progressActivity = 'Locksmith2 AD CS Scan'
@@ -160,28 +206,31 @@
             $script:InitializingStores = $true
 
             try {
-                # Scan all template techniques
-                Write-Progress -Activity $progressActivity -Status 'Scanning certificate templates...' -PercentComplete 55
-                Write-Verbose "Scanning certificate templates..."
-                $templateTechniques = @('ESC1', 'ESC2', 'ESC3c1', 'ESC3c2', 'ESC9', 'ESC4a', 'ESC4o', 'ESC13', 'ESC15', 'SchemaV1')
-                foreach ($tech in $templateTechniques) {
-                    Find-LS2VulnerableTemplate -Technique $tech | Out-Null
+                # Scan requested template techniques
+                if ($templateTechniques.Count -gt 0) {
+                    Write-Progress -Activity $progressActivity -Status 'Scanning certificate templates...' -PercentComplete 55
+                    Write-Verbose "Scanning certificate templates: $($templateTechniques -join ', ')"
+                    foreach ($tech in $templateTechniques) {
+                        Find-LS2VulnerableTemplate -Technique $tech | Out-Null
+                    }
                 }
 
-                # Scan all CA techniques
-                Write-Progress -Activity $progressActivity -Status 'Scanning certification authorities...' -PercentComplete 75
-                Write-Verbose "Scanning certification authorities..."
-                $caTechniques = @('ESC6', 'ESC7a', 'ESC7m', 'ESC8', 'ESC11', 'ESC16', 'Auditing')
-                foreach ($tech in $caTechniques) {
-                    Find-LS2VulnerableCA -Technique $tech | Out-Null
+                # Scan requested CA techniques
+                if ($caTechniques.Count -gt 0) {
+                    Write-Progress -Activity $progressActivity -Status 'Scanning certification authorities...' -PercentComplete 75
+                    Write-Verbose "Scanning certification authorities: $($caTechniques -join ', ')"
+                    foreach ($tech in $caTechniques) {
+                        Find-LS2VulnerableCA -Technique $tech | Out-Null
+                    }
                 }
 
-                # Scan all object techniques
-                Write-Progress -Activity $progressActivity -Status 'Scanning infrastructure objects...' -PercentComplete 90
-                Write-Verbose "Scanning infrastructure objects..."
-                $objectTechniques = @('ESC5a', 'ESC5o')
-                foreach ($tech in $objectTechniques) {
-                    Find-LS2VulnerableObject -Technique $tech | Out-Null
+                # Scan requested object techniques
+                if ($objectTechniques.Count -gt 0) {
+                    Write-Progress -Activity $progressActivity -Status 'Scanning infrastructure objects...' -PercentComplete 90
+                    Write-Verbose "Scanning infrastructure objects: $($objectTechniques -join ', ')"
+                    foreach ($tech in $objectTechniques) {
+                        Find-LS2VulnerableObject -Technique $tech | Out-Null
+                    }
                 }
 
                 Write-Progress -Activity $progressActivity -Status 'Scan complete.' -PercentComplete 100

--- a/Public/Invoke-Locksmith2.ps1
+++ b/Public/Invoke-Locksmith2.ps1
@@ -60,8 +60,11 @@
         Use in non-interactive or automated contexts where [System.Environment]::UserInteractive
         would otherwise trigger a prompt.
 
-        .ALIAS
-        Invoke-LS2, Locksmith2, Start-Locksmith2, Start-LS2
+        .PARAMETER Scans
+        Specifies which ESC techniques to scan for. Defaults to 'All'.
+        Accepts coarse LS1-style names (ESC3, ESC4, ESC5, ESC7) which expand to the
+        corresponding LS2 sub-techniques, as well as granular LS2 names (ESC3c1, ESC4a, etc.).
+        'EKUwu' is accepted as an alias for 'ESC15'.
 
         .INPUTS
         None. This function does not accept pipeline input.
@@ -105,6 +108,21 @@
 
         Runs audit and expands group issues into individual per-member issues.
 
+        .EXAMPLE
+        Invoke-Locksmith2 -Scans 'ESC1', 'ESC2'
+
+        Runs only the ESC1 and ESC2 template scans.
+
+        .EXAMPLE
+        Invoke-Locksmith2 -Scans 'ESC3'
+
+        Runs both ESC3 Condition 1 and Condition 2 scans.
+
+        .EXAMPLE
+        Invoke-Locksmith2 -Scans 'EKUwu'
+
+        Runs the ESC15/EKUwu scan.
+
         .LINK
         https://github.com/jakehildreth/Locksmith2
 
@@ -145,7 +163,10 @@
         [switch]$SkipForestCheck,
         [switch]$ExpandGroups,
         [switch]$Rescan,
-        [switch]$Force
+        [switch]$Force,
+        [Parameter()]
+        [ValidateSet('All', 'Auditing', 'ESC1', 'ESC2', 'ESC3', 'ESC3c1', 'ESC3c2', 'ESC4', 'ESC4a', 'ESC4o', 'ESC5', 'ESC5a', 'ESC5o', 'ESC6', 'ESC7', 'ESC7a', 'ESC7m', 'ESC8', 'ESC9', 'ESC11', 'ESC13', 'ESC15', 'EKUwu', 'ESC16', 'SchemaV1')]
+        [string[]]$Scans = 'All'
     )
 
     #requires -Version 5.1
@@ -185,9 +206,39 @@
         return
     }
 
+    # Resolve requested scan names to granular LS2 technique names
+    $scanMap = @{
+        'ESC3'  = @('ESC3c1', 'ESC3c2')
+        'ESC4'  = @('ESC4a', 'ESC4o')
+        'ESC5'  = @('ESC5a', 'ESC5o')
+        'ESC7'  = @('ESC7a', 'ESC7m')
+        'EKUwu' = @('ESC15')
+    }
+
+    $techniques = @(
+        'ESC1', 'ESC2', 'ESC3c1', 'ESC3c2', 'ESC4a', 'ESC4o',
+        'ESC5a', 'ESC5o', 'ESC6', 'ESC7a', 'ESC7m', 'ESC8', 'ESC9', 'ESC11', 'ESC13', 'ESC15', 'ESC16',
+        'Auditing', 'SchemaV1'
+    )
+
+    if ($Scans -contains 'All') {
+        $resolvedScans = $techniques
+    } else {
+        $resolvedScans = @(
+            foreach ($scan in $Scans) {
+                if ($scanMap.ContainsKey($scan)) {
+                    $scanMap[$scan]
+                } else {
+                    $scan
+                }
+            }
+        ) | Select-Object -Unique
+    }
+
     $initParams = @{
         Forest     = $ctx.Forest
         Credential = $ctx.Credential
+        Scans      = $resolvedScans
     }
     if ($Rescan) {
         $initParams['Rescan'] = $true
@@ -206,19 +257,14 @@
     }
 
     Write-Verbose "`nScan complete. Issue summary:"
-    $techniques = @(
-        'ESC1', 'ESC2', 'ESC3c1', 'ESC3c2', 'ESC4a', 'ESC4o',
-        'ESC5a', 'ESC5o', 'ESC6', 'ESC7a', 'ESC7m', 'ESC8', 'ESC9', 'ESC11', 'ESC13', 'ESC15', 'ESC16',
-        'Auditing', 'SchemaV1'
-    )
 
-    foreach ($technique in $techniques) {
+    foreach ($technique in $resolvedScans) {
         $issueCount = Get-IssueCount -Technique $technique
         Write-Verbose "  $($technique): $issueCount issue(s)"
     }
 
-    # Get all flattened issues
-    $allIssues = Get-FlattenedIssues
+    # Get flattened issues, limited to the requested scans
+    $allIssues = @(Get-FlattenedIssues | Where-Object { $_.Technique -in $resolvedScans })
 
     # Expand groups if requested
     if ($ExpandGroups) {

--- a/Tests/Private/Initialize/Initialize-LS2Scan.Tests.ps1
+++ b/Tests/Private/Initialize/Initialize-LS2Scan.Tests.ps1
@@ -99,5 +99,64 @@ Describe 'Initialize-LS2Scan' -Tag 'Unit' {
                 $result | Should -BeOfType [bool]
             }
         }
+
+        Context 'When -Scans is specified' {
+            BeforeEach {
+                $script:AdcsObjectStore['CN=Fake,DC=contoso,DC=com'] = New-MockLS2AdcsObject
+                Mock 'Set-LS2Forest' { }
+                Mock 'Set-LS2Credential' { }
+                Mock 'Get-RootDSE' { $null }
+                Mock 'Initialize-DomainStore' { }
+                Mock 'Initialize-PrincipalDefinitions' { }
+                Mock 'Initialize-AdcsObjectStore' { }
+                Mock 'Find-LS2VulnerableTemplate' { }
+                Mock 'Find-LS2VulnerableCA' { }
+                Mock 'Find-LS2VulnerableObject' { }
+            }
+
+            It 'should call Find-LS2VulnerableTemplate for ESC1 when -Scans ESC1 is specified' {
+                Initialize-LS2Scan -Scans 'ESC1' | Out-Null
+                Should -Invoke 'Find-LS2VulnerableTemplate' -Times 1 -ParameterFilter { $Technique -eq 'ESC1' }
+                Should -Invoke 'Find-LS2VulnerableCA' -Times 0
+                Should -Invoke 'Find-LS2VulnerableObject' -Times 0
+            }
+
+            It 'should expand ESC3 to ESC3c1 and ESC3c2' {
+                Initialize-LS2Scan -Scans 'ESC3' | Out-Null
+                Should -Invoke 'Find-LS2VulnerableTemplate' -Times 1 -ParameterFilter { $Technique -eq 'ESC3c1' }
+                Should -Invoke 'Find-LS2VulnerableTemplate' -Times 1 -ParameterFilter { $Technique -eq 'ESC3c2' }
+            }
+
+            It 'should expand ESC4 to ESC4a and ESC4o' {
+                Initialize-LS2Scan -Scans 'ESC4' | Out-Null
+                Should -Invoke 'Find-LS2VulnerableTemplate' -Times 1 -ParameterFilter { $Technique -eq 'ESC4a' }
+                Should -Invoke 'Find-LS2VulnerableTemplate' -Times 1 -ParameterFilter { $Technique -eq 'ESC4o' }
+            }
+
+            It 'should expand ESC5 to ESC5a and ESC5o' {
+                Initialize-LS2Scan -Scans 'ESC5' | Out-Null
+                Should -Invoke 'Find-LS2VulnerableObject' -Times 1 -ParameterFilter { $Technique -eq 'ESC5a' }
+                Should -Invoke 'Find-LS2VulnerableObject' -Times 1 -ParameterFilter { $Technique -eq 'ESC5o' }
+            }
+
+            It 'should expand ESC7 to ESC7a and ESC7m' {
+                Initialize-LS2Scan -Scans 'ESC7' | Out-Null
+                Should -Invoke 'Find-LS2VulnerableCA' -Times 1 -ParameterFilter { $Technique -eq 'ESC7a' }
+                Should -Invoke 'Find-LS2VulnerableCA' -Times 1 -ParameterFilter { $Technique -eq 'ESC7m' }
+            }
+
+            It 'should run the full technique list when -Scans is omitted' {
+                Initialize-LS2Scan | Out-Null
+                Should -Invoke 'Find-LS2VulnerableTemplate' -Times -1
+                Should -Invoke 'Find-LS2VulnerableCA' -Times -1
+                Should -Invoke 'Find-LS2VulnerableObject' -Times -1
+            }
+
+            It 'should not call Find-LS2VulnerableCA for template-only scans' {
+                Initialize-LS2Scan -Scans 'ESC1', 'ESC2' | Out-Null
+                Should -Invoke 'Find-LS2VulnerableCA' -Times 0
+                Should -Invoke 'Find-LS2VulnerableObject' -Times 0
+            }
+        }
     }
 }

--- a/Tests/Public/Invoke-Locksmith2.Tests.ps1
+++ b/Tests/Public/Invoke-Locksmith2.Tests.ps1
@@ -152,5 +152,109 @@ InModuleScope 'Locksmith2' {
             Should -Invoke 'Initialize-LS2Scan' -Times 0
             Should -Invoke 'Show-PrivilegeContext' -Times 0
         }
+
+        Context 'When -Scans is specified' {
+            It 'should default -Scans to All and forward all techniques to Initialize-LS2Scan' {
+                Invoke-Locksmith2 | Out-Null
+                Should -Invoke 'Initialize-LS2Scan' -Times 1 -ParameterFilter {
+                    $Scans -contains 'ESC1' -and
+                    $Scans -contains 'ESC3c1' -and
+                    $Scans -contains 'ESC3c2' -and
+                    $Scans -contains 'ESC4a' -and
+                    $Scans -contains 'ESC4o' -and
+                    $Scans -contains 'ESC5a' -and
+                    $Scans -contains 'ESC5o' -and
+                    $Scans -contains 'ESC6' -and
+                    $Scans -contains 'ESC7a' -and
+                    $Scans -contains 'ESC7m' -and
+                    $Scans -contains 'ESC8' -and
+                    $Scans -contains 'ESC9' -and
+                    $Scans -contains 'ESC11' -and
+                    $Scans -contains 'ESC13' -and
+                    $Scans -contains 'ESC15' -and
+                    $Scans -contains 'ESC16' -and
+                    $Scans -contains 'Auditing' -and
+                    $Scans -contains 'SchemaV1'
+                }
+            }
+
+            It 'should forward only ESC1 to Initialize-LS2Scan when -Scans ESC1 is specified' {
+                Invoke-Locksmith2 -Scans 'ESC1' | Out-Null
+                Should -Invoke 'Initialize-LS2Scan' -Times 1 -ParameterFilter {
+                    $Scans.Count -eq 1 -and $Scans[0] -eq 'ESC1'
+                }
+            }
+
+            It 'should expand ESC3 to ESC3c1 and ESC3c2 when forwarded to Initialize-LS2Scan' {
+                Invoke-Locksmith2 -Scans 'ESC3' | Out-Null
+                Should -Invoke 'Initialize-LS2Scan' -Times 1 -ParameterFilter {
+                    $Scans.Count -eq 2 -and
+                    $Scans -contains 'ESC3c1' -and
+                    $Scans -contains 'ESC3c2'
+                }
+            }
+
+            It 'should expand ESC4 to ESC4a and ESC4o when forwarded to Initialize-LS2Scan' {
+                Invoke-Locksmith2 -Scans 'ESC4' | Out-Null
+                Should -Invoke 'Initialize-LS2Scan' -Times 1 -ParameterFilter {
+                    $Scans.Count -eq 2 -and
+                    $Scans -contains 'ESC4a' -and
+                    $Scans -contains 'ESC4o'
+                }
+            }
+
+            It 'should expand ESC5 to ESC5a and ESC5o when forwarded to Initialize-LS2Scan' {
+                Invoke-Locksmith2 -Scans 'ESC5' | Out-Null
+                Should -Invoke 'Initialize-LS2Scan' -Times 1 -ParameterFilter {
+                    $Scans.Count -eq 2 -and
+                    $Scans -contains 'ESC5a' -and
+                    $Scans -contains 'ESC5o'
+                }
+            }
+
+            It 'should expand ESC7 to ESC7a and ESC7m when forwarded to Initialize-LS2Scan' {
+                Invoke-Locksmith2 -Scans 'ESC7' | Out-Null
+                Should -Invoke 'Initialize-LS2Scan' -Times 1 -ParameterFilter {
+                    $Scans.Count -eq 2 -and
+                    $Scans -contains 'ESC7a' -and
+                    $Scans -contains 'ESC7m'
+                }
+            }
+
+            It 'should map EKUwu to ESC15 when forwarded to Initialize-LS2Scan' {
+                Invoke-Locksmith2 -Scans 'EKUwu' | Out-Null
+                Should -Invoke 'Initialize-LS2Scan' -Times 1 -ParameterFilter {
+                    $Scans.Count -eq 1 -and $Scans[0] -eq 'ESC15'
+                }
+            }
+
+            It 'should accept multiple -Scans values and resolve them' {
+                Invoke-Locksmith2 -Scans 'ESC1', 'ESC3' | Out-Null
+                Should -Invoke 'Initialize-LS2Scan' -Times 1 -ParameterFilter {
+                    $Scans.Count -eq 3 -and
+                    $Scans -contains 'ESC1' -and
+                    $Scans -contains 'ESC3c1' -and
+                    $Scans -contains 'ESC3c2'
+                }
+            }
+
+            It 'should call Get-IssueCount only for the requested techniques' {
+                Mock 'Get-IssueCount' { 0 }
+                Invoke-Locksmith2 -Scans 'ESC1' | Out-Null
+                Should -Invoke 'Get-IssueCount' -Times 1 -ParameterFilter { $Technique -eq 'ESC1' }
+            }
+
+            It 'should filter returned issues to the requested techniques' {
+                $script:mockIssue2 = [LS2Issue]@{
+                    Technique = 'ESC6'; Forest = 'contoso.com'; Name = 'TestCA'
+                    DistinguishedName = 'CN=TestCA,...'; ObjectClass = 'pKIEnrollmentService'
+                    IdentityReference = 'Everyone'
+                }
+                Mock 'Get-FlattenedIssues' { @($script:mockIssue, $script:mockIssue2) }
+                $result = @(Invoke-Locksmith2 -Scans 'ESC1')
+                $result.Count | Should -Be 1
+                $result[0].Technique | Should -Be 'ESC1'
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Restores the `-Scans` parameter from Locksmith 1, allowing users to run only specific ESC technique scans instead of the full audit.

## What changed

- Added `[string[]]$Scans = 'All'` to `Invoke-Locksmith2` with a 25-value `ValidateSet`
- Coarse LS1-style names expand to LS2 sub-techniques:
  - `ESC3` → `ESC3c1`, `ESC3c2`
  - `ESC4` → `ESC4a`, `ESC4o`
  - `ESC5` → `ESC5a`, `ESC5o`
  - `ESC7` → `ESC7a`, `ESC7m`
- `EKUwu` is accepted as an alias for `ESC15`
- `Initialize-LS2Scan` now accepts `-Scans` and runs only the requested `Find-LS2Vulnerable*` calls
- Issue summary and pipeline output are filtered to the requested scans
- Added focused Pester coverage for both `Invoke-Locksmith2` and `Initialize-LS2Scan`
- Bumped `ModuleVersion` to `2026.7.51145`

## Test results

- Full Pester suite: **2243 passed, 0 failed, 29 skipped** in both PowerShell 5.1 and PowerShell 7
- Focused `-Scans` tests: **44 passed, 0 failed**

Closes #47