### PR TITLE
feat(dashboard): add context-aware summary cards to New-LS2Dashboard

### DIFF
--- a/Locksmith2.psd1
+++ b/Locksmith2.psd1
@@ -8,7 +8,7 @@
     Description='An AD CS toolkit for AD Admins, Defensive Security Professionals, and Filthy Red Teamers'
     FunctionsToExport=@('*')
     GUID='e32f7d0d-2b10-4db2-b776-a193958e3d69'
-    ModuleVersion='2026.7.51145'
+    ModuleVersion='2026.7.62028'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{

--- a/Locksmith2.psd1
+++ b/Locksmith2.psd1
@@ -8,7 +8,7 @@
     Description='An AD CS toolkit for AD Admins, Defensive Security Professionals, and Filthy Red Teamers'
     FunctionsToExport=@('*')
     GUID='e32f7d0d-2b10-4db2-b776-a193958e3d69'
-    ModuleVersion='2026.7.62042'
+    ModuleVersion='2026.7.71534'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{

--- a/Locksmith2.psd1
+++ b/Locksmith2.psd1
@@ -8,7 +8,7 @@
     Description='An AD CS toolkit for AD Admins, Defensive Security Professionals, and Filthy Red Teamers'
     FunctionsToExport=@('*')
     GUID='e32f7d0d-2b10-4db2-b776-a193958e3d69'
-    ModuleVersion='2026.7.62028'
+    ModuleVersion='2026.7.62042'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{

--- a/Public/New-LS2Dashboard.ps1
+++ b/Public/New-LS2Dashboard.ps1
@@ -2,64 +2,64 @@
     <#
     .SYNOPSIS
     Generates an interactive HTML dashboard for Locksmith2 scan results.
-    
+
     .DESCRIPTION
     Creates a comprehensive HTML dashboard with left navigation menu showing:
     - All issues with expanded principals
     - Issues filtered by type (Template, CA, Object)
     - Risky principals analysis.
-    
+
     .PARAMETER FilePath
     Path where the HTML dashboard will be saved.
     Default: Locksmith2-Dashboard.html in the current working directory.
-    
+
     .PARAMETER Show
     Opens the dashboard in the default browser after generation.
     Defaults to $true when no parameters are specified.
-    
+
     .PARAMETER ExpandGroups
     Expands group principals into individual member issues.
-    
+
     .PARAMETER Online
     Uses online CDN resources instead of embedding CSS/JS.
     Results in smaller file size but requires internet connection to view.
-    
+
     .INPUTS
     None. This function does not accept pipeline input.
-    
+
     .OUTPUTS
     None. Generates an HTML file at the specified path.
-    
+
     .EXAMPLE
     Invoke-Locksmith2
     New-LS2Dashboard -FilePath C:\Reports\locksmith-dashboard.html -Show
-    
+
     Runs a scan and generates an interactive dashboard.
-    
+
     .EXAMPLE
     New-LS2Dashboard -ExpandGroups -Show
-    
+
     Generates dashboard with group memberships expanded to individual principals.
-    
+
     .EXAMPLE
     New-LS2Dashboard -FilePath C:\Reports\report.html -Online
-    
+
     Generates a smaller dashboard file using online CDN resources.
-    
+
     .NOTES
     Author: Jake Hildreth (@jakehildreth)
     Requires: PSWriteHTML module (https://github.com/EvotecIT/PSWriteHTML)
     Requires: PowerShell 5.1 or later
-    
+
     The dashboard reads from the current IssueStore. Run Invoke-Locksmith2 or
     Find-LS2Vulnerable* functions first to populate the store with scan data.
-    
+
     .LINK
     Invoke-Locksmith2
-    
+
     .LINK
     Find-LS2RiskyPrincipal
-    
+
     .LINK
     Get-FlattenedIssues
     #>
@@ -67,17 +67,17 @@
     param(
         [Parameter()]
         [string]$FilePath,
-        
+
         [Parameter()]
         [bool]$Show = $true,
-        
+
         [Parameter()]
         [switch]$ExpandGroups,
-        
+
         [Parameter()]
         [switch]$Online
     )
-    
+
     #requires -Version 5.1
 
     if (-not $FilePath) {
@@ -133,14 +133,14 @@
     # Techniques = $null  -> no filter (All Issues).
     # IsPrincipals = $true -> use the principals table and formatting instead of issue table.
     $tabDefs = [ordered]@{
-        'All Issues'        = @{ Icon = 'exclamation-triangle'; IconColor = 'Red';    Techniques = $null;                                                          Subtitle = 'All discovered AD CS vulnerabilities with principals expanded';                                             Title = 'All AD CS Security Issues';           SortColumn = 'Technique' }
-        'Templates'         = @{ Icon = 'file-contract';        IconColor = 'Orange'; Techniques = @('ESC1','ESC2','ESC3c1','ESC3c2','ESC4a','ESC4o','ESC9');      Subtitle = 'Misconfigured templates allowing SAN abuse, weak enrollment restrictions, or enrollment agent exploitation'; Title = 'Template Vulnerabilities';            SortColumn = 'Technique' }
-        'CAs'               = @{ Icon = 'certificate';          IconColor = 'Yellow'; Techniques = @('ESC6','ESC7a','ESC7m','ESC8','ESC11','ESC16');               Subtitle = 'Insecure CA configurations and dangerous role assignments (ESC6, ESC7, ESC8, ESC11, ESC16)';             Title = 'CA Configuration Issues';             SortColumn = 'Name'      }
-        'Objects'           = @{ Icon = 'folder';               IconColor = 'Blue';   Techniques = @('ESC5a','ESC5o');                                             Subtitle = 'Dangerous permissions on PKI infrastructure objects (ESC5)';                                               Title = 'Infrastructure Object Issues';        SortColumn = 'Name'      }
+        'All Issues'        = @{ Icon = 'exclamation-triangle'; IconColor = 'Red';    Techniques = $null;                                                          Subtitle = 'All discovered AD CS vulnerabilities with principals expanded';                                             Title = 'All AD CS Security Issues';           SortColumn = 'Technique'; SummaryLabel = 'Issue' }
+        'Templates'         = @{ Icon = 'file-contract';        IconColor = 'Orange'; Techniques = @('ESC1','ESC2','ESC3c1','ESC3c2','ESC4a','ESC4o','ESC9');      Subtitle = 'Misconfigured templates allowing SAN abuse, weak enrollment restrictions, or enrollment agent exploitation'; Title = 'Template Vulnerabilities';            SortColumn = 'Technique'; SummaryLabel = 'Template Issue' }
+        'CAs'               = @{ Icon = 'certificate';          IconColor = 'Yellow'; Techniques = @('ESC6','ESC7a','ESC7m','ESC8','ESC11','ESC16');               Subtitle = 'Insecure CA configurations and dangerous role assignments (ESC6, ESC7, ESC8, ESC11, ESC16)';             Title = 'CA Configuration Issues';             SortColumn = 'Name';      SummaryLabel = 'CA Issue' }
+        'Objects'           = @{ Icon = 'folder';               IconColor = 'Blue';   Techniques = @('ESC5a','ESC5o');                                             Subtitle = 'Dangerous permissions on PKI infrastructure objects (ESC5)';                                               Title = 'Infrastructure Object Issues';        SortColumn = 'Name';      SummaryLabel = 'Object Issue' }
         'Risky Principals'  = @{ Icon = 'user-shield';          IconColor = 'Purple'; IsPrincipals = $true;                                                        Subtitle = 'Ranked by number of exploitable AD CS vulnerabilities' }
-        'Dangerous Configurations' = @{ Icon = 'cog';                  IconColor = 'Red';    Techniques = @('ESC1','ESC2','ESC3c1','ESC3c2','ESC6','ESC8','ESC9','ESC11','ESC16'); Subtitle = 'Insecure template/CA configurations enabling certificate abuse (ESC1, ESC2, ESC6, ESC8, ESC9, ESC11, ESC16)'; Title = 'Configuration-Based Vulnerabilities'; SortColumn = 'Technique' }
-        'Access Control'    = @{ Icon = 'key';                  IconColor = 'Green';  Techniques = @('ESC4a','ESC5a');                                             Subtitle = 'Excessive write/modify permissions on templates and PKI objects (ESC4a, ESC5a)';                            Title = 'Write/Modify Permission Issues';       SortColumn = 'ActiveDirectoryRights' }
-        'Ownership'         = @{ Icon = 'crown';                IconColor = 'Gold';   Techniques = @('ESC4o','ESC5o');                                             Subtitle = 'Non-standard owners with full control over templates or PKI objects (ESC4o, ESC5o)';                      Title = 'Dangerous Ownership Configurations';   SortColumn = 'Owner'     }
+        'Dangerous Configurations' = @{ Icon = 'cog';                  IconColor = 'Red';    Techniques = @('ESC1','ESC2','ESC3c1','ESC3c2','ESC6','ESC8','ESC9','ESC11','ESC16'); Subtitle = 'Insecure template/CA configurations enabling certificate abuse (ESC1, ESC2, ESC6, ESC8, ESC9, ESC11, ESC16)'; Title = 'Configuration-Based Vulnerabilities'; SortColumn = 'Technique'; SummaryLabel = 'Configuration Issue' }
+        'Access Control'    = @{ Icon = 'key';                  IconColor = 'Green';  Techniques = @('ESC4a','ESC5a');                                             Subtitle = 'Excessive write/modify permissions on templates and PKI objects (ESC4a, ESC5a)';                            Title = 'Write/Modify Permission Issues';       SortColumn = 'ActiveDirectoryRights'; SummaryLabel = 'Access Control Issue' }
+        'Ownership'         = @{ Icon = 'crown';                IconColor = 'Gold';   Techniques = @('ESC4o','ESC5o');                                             Subtitle = 'Non-standard owners with full control over templates or PKI objects (ESC4o, ESC5o)';                      Title = 'Dangerous Ownership Configurations';   SortColumn = 'Owner';     SummaryLabel = 'Ownership Issue' }
     }
 
     # Build filtered + projected table for each issue tab
@@ -165,24 +165,6 @@
     $generatedAt  = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
     $scanUser     = if ($script:Credential) { $script:Credential.UserName } else { [System.Security.Principal.WindowsIdentity]::GetCurrent().Name }
     $scanComputer = "$env:USERDOMAIN\$env:COMPUTERNAME"
-
-    # Summary metrics for the dashboard header cards
-    $totalIssues      = @($allIssues).Count
-    $issueRiskNames   = foreach ($issue in $allIssues) {
-        if ($issue.RiskName) { $issue.RiskName } else { 'Unrated' }
-    }
-    $riskGroups       = $issueRiskNames | Group-Object -NoElement
-    $riskCountMap     = @{}
-    foreach ($group in $riskGroups) {
-        $riskCountMap[$group.Name] = $group.Count
-    }
-
-    $criticalCount     = if ($riskCountMap.ContainsKey('Critical'))     { $riskCountMap['Critical'] }     else { 0 }
-    $highCount         = if ($riskCountMap.ContainsKey('High'))         { $riskCountMap['High'] }         else { 0 }
-    $mediumCount       = if ($riskCountMap.ContainsKey('Medium'))       { $riskCountMap['Medium'] }       else { 0 }
-    $lowCount          = if ($riskCountMap.ContainsKey('Low'))          { $riskCountMap['Low'] }          else { 0 }
-    $informationalCount = if ($riskCountMap.ContainsKey('Informational')) { $riskCountMap['Informational'] } else { 0 }
-    $unratedCount      = if ($riskCountMap.ContainsKey('Unrated'))      { $riskCountMap['Unrated'] }      else { 0 }
 
     # Resolve logo and encode as base64 data URI for self-contained HTML
     $logoSource = $null
@@ -293,14 +275,30 @@
                     New-HTMLHorizontalLine
                     New-HTMLText -Text "$(@($principalsTable).Count) principals  --  $($def.Subtitle)" -Color '#666' -FontSize 13 -FontStyle italic
                 } else {
-                    if ($tabName -eq 'All Issues' -and $totalIssues -gt 0) {
+                    if ($def.Issues.Count -gt 0) {
+                        $tabRiskNames = foreach ($issue in $def.Issues) {
+                            if ($issue.RiskName) { $issue.RiskName } else { 'Unrated' }
+                        }
+                        $tabRiskGroups = $tabRiskNames | Group-Object -NoElement
+                        $tabRiskCountMap = @{}
+                        foreach ($group in $tabRiskGroups) {
+                            $tabRiskCountMap[$group.Name] = $group.Count
+                        }
+
+                        $tabTotal      = $def.Issues.Count
+                        $tabCritical   = if ($tabRiskCountMap.ContainsKey('Critical'))     { $tabRiskCountMap['Critical'] }     else { 0 }
+                        $tabHigh       = if ($tabRiskCountMap.ContainsKey('High'))         { $tabRiskCountMap['High'] }         else { 0 }
+                        $tabMedium     = if ($tabRiskCountMap.ContainsKey('Medium'))       { $tabRiskCountMap['Medium'] }       else { 0 }
+                        $tabLow        = if ($tabRiskCountMap.ContainsKey('Low'))          { $tabRiskCountMap['Low'] }          else { 0 }
+                        $tabInfo       = if ($tabRiskCountMap.ContainsKey('Informational')) { $tabRiskCountMap['Informational'] } else { 0 }
+
                         New-HTMLSection -HeaderText 'Scan Summary' -Content {
-                            & $summaryCard -Label 'Total Issues' -Value $totalIssues -Color '#333'
-                            & $summaryCard -Label 'Critical' -Value $criticalCount -Color '#b71c1c'
-                            & $summaryCard -Label 'High' -Value $highCount -Color '#e53935'
-                            & $summaryCard -Label 'Medium' -Value $mediumCount -Color '#ff9800'
-                            & $summaryCard -Label 'Low' -Value $lowCount -Color '#fdd835'
-                            & $summaryCard -Label 'Informational' -Value $informationalCount -Color '#1976d2'
+                            & $summaryCard -Label "Total $($def.SummaryLabel)s" -Value $tabTotal -Color '#333'
+                            & $summaryCard -Label 'Critical' -Value $tabCritical -Color '#b71c1c'
+                            & $summaryCard -Label 'High' -Value $tabHigh -Color '#e53935'
+                            & $summaryCard -Label 'Medium' -Value $tabMedium -Color '#ff9800'
+                            & $summaryCard -Label 'Low' -Value $tabLow -Color '#fdd835'
+                            & $summaryCard -Label 'Informational' -Value $tabInfo -Color '#1976d2'
                         }
                         New-HTMLHorizontalLine
                     }

--- a/Public/New-LS2Dashboard.ps1
+++ b/Public/New-LS2Dashboard.ps1
@@ -165,6 +165,25 @@
     $generatedAt  = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
     $scanUser     = if ($script:Credential) { $script:Credential.UserName } else { [System.Security.Principal.WindowsIdentity]::GetCurrent().Name }
     $scanComputer = "$env:USERDOMAIN\$env:COMPUTERNAME"
+
+    # Summary metrics for the dashboard header cards
+    $totalIssues      = @($allIssues).Count
+    $issueRiskNames   = foreach ($issue in $allIssues) {
+        if ($issue.RiskName) { $issue.RiskName } else { 'Unrated' }
+    }
+    $riskGroups       = $issueRiskNames | Group-Object -NoElement
+    $riskCountMap     = @{}
+    foreach ($group in $riskGroups) {
+        $riskCountMap[$group.Name] = $group.Count
+    }
+
+    $criticalCount     = if ($riskCountMap.ContainsKey('Critical'))     { $riskCountMap['Critical'] }     else { 0 }
+    $highCount         = if ($riskCountMap.ContainsKey('High'))         { $riskCountMap['High'] }         else { 0 }
+    $mediumCount       = if ($riskCountMap.ContainsKey('Medium'))       { $riskCountMap['Medium'] }       else { 0 }
+    $lowCount          = if ($riskCountMap.ContainsKey('Low'))          { $riskCountMap['Low'] }          else { 0 }
+    $informationalCount = if ($riskCountMap.ContainsKey('Informational')) { $riskCountMap['Informational'] } else { 0 }
+    $unratedCount      = if ($riskCountMap.ContainsKey('Unrated'))      { $riskCountMap['Unrated'] }      else { 0 }
+
     # Resolve logo and encode as base64 data URI for self-contained HTML
     $logoSource = $null
     $moduleBase = (Get-Module -Name Locksmith2 -ErrorAction SilentlyContinue).ModuleBase
@@ -229,6 +248,19 @@
         New-HTMLTableCondition -Name 'IssueCount' -ComparisonType number -Operator gt -Value 10 -BackgroundColor '#ef5350' -Color White
     }
 
+    # Renders one summary card. Called inside New-HTMLSection.
+    $summaryCard = {
+        param(
+            [string]$Label,
+            [string]$Value,
+            [string]$Color
+        )
+        New-HTMLPanel {
+            New-HTMLText -Text $Label -FontSize 12 -Color '#888' -Alignment center
+            New-HTMLText -Text $Value -FontSize 32 -FontWeight bold -Color $Color -Alignment center
+        }
+    }
+
     $tableButtons = @('copyHtml5', 'excelHtml5', 'csvHtml5', 'pdfHtml5', 'searchBuilder', 'searchPanes')
 
     New-HTML -TitleText "Locksmith 2 Dashboard - $forestName - $generatedAt" -Online:$Online -FilePath $FilePath -Show:$Show {
@@ -261,6 +293,18 @@
                     New-HTMLHorizontalLine
                     New-HTMLText -Text "$(@($principalsTable).Count) principals  --  $($def.Subtitle)" -Color '#666' -FontSize 13 -FontStyle italic
                 } else {
+                    if ($tabName -eq 'All Issues' -and $totalIssues -gt 0) {
+                        New-HTMLSection -HeaderText 'Scan Summary' -Content {
+                            & $summaryCard -Label 'Total Issues' -Value $totalIssues -Color '#333'
+                            & $summaryCard -Label 'Critical' -Value $criticalCount -Color '#b71c1c'
+                            & $summaryCard -Label 'High' -Value $highCount -Color '#e53935'
+                            & $summaryCard -Label 'Medium' -Value $mediumCount -Color '#ff9800'
+                            & $summaryCard -Label 'Low' -Value $lowCount -Color '#fdd835'
+                            & $summaryCard -Label 'Informational' -Value $informationalCount -Color '#1976d2'
+                        }
+                        New-HTMLHorizontalLine
+                    }
+
                     New-HTMLTable -DataTable $def.Table `
                         -Filtering `
                         -PagingLength 25 `


### PR DESCRIPTION
Adds summary cards to every issue tab in `New-LS2Dashboard`, showing context-aware totals and risk-level breakdowns.

- Compute risk-level counts per tab from each tab's filtered `Issues`
- Add `SummaryLabel` to each issue tab definition for contextual "Total X Issues" labels
- Render Total/Critical/High/Medium/Low/Informational cards above each issue table
- Remove global dashboard metrics now that counts are tab-scoped
- Bump module version to 2026.7.71534
- Remove trailing-whitespace cleanup from pre-commit hook