### PR TITLE
feat(dashboard): clickable summary cards with union severity filtering and RiskValue sort

### DIFF
--- a/Locksmith2.psd1
+++ b/Locksmith2.psd1
@@ -8,7 +8,7 @@
     Description='An AD CS toolkit for AD Admins, Defensive Security Professionals, and Filthy Red Teamers'
     FunctionsToExport=@('*')
     GUID='e32f7d0d-2b10-4db2-b776-a193958e3d69'
-    ModuleVersion='2026.7.71534'
+    ModuleVersion='2026.7.82045'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{

--- a/Locksmith2.psd1
+++ b/Locksmith2.psd1
@@ -8,7 +8,7 @@
     Description='An AD CS toolkit for AD Admins, Defensive Security Professionals, and Filthy Red Teamers'
     FunctionsToExport=@('*')
     GUID='e32f7d0d-2b10-4db2-b776-a193958e3d69'
-    ModuleVersion='2026.7.82045'
+    ModuleVersion='2026.7.82104'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{

--- a/Public/New-LS2Dashboard.ps1
+++ b/Public/New-LS2Dashboard.ps1
@@ -231,15 +231,22 @@
     }
 
     # Renders one summary card. Called inside New-HTMLSection.
+    # Cards are clickable: they filter the tab's DataTable by RiskName. Clicking the
+    # active card again clears the filter. Non-selected cards are faded via CSS class.
     $summaryCard = {
         param(
             [string]$Label,
             [string]$Value,
-            [string]$Color
+            [string]$Color,
+            [string]$TableId,
+            [string]$FilterValue,
+            [string]$CardClass = 'summary-card'
         )
-        New-HTMLPanel {
-            New-HTMLText -Text $Label -FontSize 12 -Color '#888' -Alignment center
-            New-HTMLText -Text $Value -FontSize 32 -FontWeight bold -Color $Color -Alignment center
+        New-HTMLTag -Tag 'div' -Attributes @{ class = "$CardClass summary-card-clickable"; 'data-filter' = $FilterValue; 'data-table-id' = $TableId } {
+            New-HTMLPanel {
+                New-HTMLText -Text $Label -FontSize 12 -Color '#888' -Alignment center
+                New-HTMLText -Text $Value -FontSize 32 -FontWeight bold -Color $Color -Alignment center
+            }
         }
     }
 
@@ -250,7 +257,16 @@
         # Persistent header — logo + collection context. New-HTMLHeader renders outside the tab
         # container and does not create a tab-content slot (unlike New-HTMLSection/Panel at this level).
         New-HTMLHeader {
-            Add-HTMLStyle -Content 'header { text-align: center; padding: 12px 0; } header img { max-width: 50%; height: auto; display: inline-block; }'
+            Add-HTMLStyle -Content @'
+header { text-align: center; padding: 12px 0; }
+header img { max-width: 50%; height: auto; display: inline-block; }
+.summary-section { display: flex; flex-wrap: wrap; gap: 12px; width: 100%; }
+.summary-card { display: flex; flex: 1 1 0; min-width: 140px; cursor: pointer; transition: opacity 0.2s ease-in-out, transform 0.1s ease-in-out; }
+.summary-card > .flexPanel { width: 100%; }
+.summary-card:hover { opacity: 1 !important; transform: translateY(-2px); }
+.summary-card-active > .flexPanel { outline: 2px solid #333; }
+.summary-section:has(.summary-card-active) .summary-card:not(.summary-card-active) { opacity: 0.45; }
+'@
             if ($logoSource) {
                 New-HTMLImage -Source $logoSource -Width '50%' -AlternativeText 'Locksmith 2'
             }
@@ -263,6 +279,7 @@
 
         foreach ($tabName in $tabDefs.Keys) {
             $def = $tabDefs[$tabName]
+            $tableId = if ($def.IsPrincipals) { $null } else { 'IssuesTable-' + ($tabName -replace '\s+', '-' -replace '[^A-Za-z0-9-]', '') }
             New-HTMLTab -Name $tabName -IconSolid $def.Icon -IconColor $def.IconColor {
                 if ($def.IsPrincipals) {
                     New-HTMLTable -DataTable $principalsTable `
@@ -293,17 +310,44 @@
                         $tabInfo       = if ($tabRiskCountMap.ContainsKey('Informational')) { $tabRiskCountMap['Informational'] } else { 0 }
 
                         New-HTMLSection -HeaderText 'Scan Summary' -Content {
-                            & $summaryCard -Label "Total $($def.SummaryLabel)s" -Value $tabTotal -Color '#333'
-                            & $summaryCard -Label 'Critical' -Value $tabCritical -Color '#b71c1c'
-                            & $summaryCard -Label 'High' -Value $tabHigh -Color '#e53935'
-                            & $summaryCard -Label 'Medium' -Value $tabMedium -Color '#ff9800'
-                            & $summaryCard -Label 'Low' -Value $tabLow -Color '#fdd835'
-                            & $summaryCard -Label 'Informational' -Value $tabInfo -Color '#1976d2'
+                            New-HTMLTag -Tag 'div' -Attributes @{ class = 'summary-section'; 'data-table-id' = $tableId } {
+                                & $summaryCard -Label "Total $($def.SummaryLabel)s" -Value $tabTotal -Color '#333' -TableId $tableId -FilterValue ''
+                                & $summaryCard -Label 'Critical' -Value $tabCritical -Color '#b71c1c' -TableId $tableId -FilterValue 'Critical'
+                                & $summaryCard -Label 'High' -Value $tabHigh -Color '#e53935' -TableId $tableId -FilterValue 'High'
+                                & $summaryCard -Label 'Medium' -Value $tabMedium -Color '#ff9800' -TableId $tableId -FilterValue 'Medium'
+                                & $summaryCard -Label 'Low' -Value $tabLow -Color '#fdd835' -TableId $tableId -FilterValue 'Low'
+                                & $summaryCard -Label 'Informational' -Value $tabInfo -Color '#1976d2' -TableId $tableId -FilterValue 'Informational'
+                            }
+                            Add-HTMLScript -Content "
+document.addEventListener('DOMContentLoaded', function() {
+    var section = document.querySelector('.summary-section[data-table-id=\'$tableId\']');
+    if (!section) return;
+    section.addEventListener('click', function(e) {
+        var card = e.target.closest('.summary-card');
+        if (!card) return;
+        var tableId = section.getAttribute('data-table-id');
+        var table = document.getElementById(tableId);
+        if (!table) return;
+        var dt = (window.jQuery && jQuery.fn.DataTable) ? jQuery(table).DataTable() : null;
+        if (!dt) return;
+        var filter = card.getAttribute('data-filter') || '';
+        var active = card.classList.contains('summary-card-active');
+        section.querySelectorAll('.summary-card').forEach(function(c) { c.classList.remove('summary-card-active'); });
+        if (active || filter === '') {
+            dt.column(1).search('').draw();
+        } else {
+            dt.column(1).search(filter).draw();
+            card.classList.add('summary-card-active');
+        }
+    });
+});
+"
                         }
                         New-HTMLHorizontalLine
                     }
 
                     New-HTMLTable -DataTable $def.Table `
+                        -DataTableID $tableId `
                         -Filtering `
                         -PagingLength 25 `
                         -Buttons $tableButtons `

--- a/Public/New-LS2Dashboard.ps1
+++ b/Public/New-LS2Dashboard.ps1
@@ -361,7 +361,8 @@ document.addEventListener('DOMContentLoaded', function() {
                         -PagingLength 25 `
                         -Buttons $tableButtons `
                         -Title $def.Title `
-                        -DefaultSortColumn $def.SortColumn {& $issueFormatting}
+                        -DefaultSortColumn 'RiskValue' `
+                        -DefaultSortOrder Descending {& $issueFormatting}
                     New-HTMLHorizontalLine
                     New-HTMLText -Text "$($def.Issues.Count) issues  --  $($def.Subtitle)" -Color '#666' -FontSize 13 -FontStyle italic
                 }

--- a/Public/New-LS2Dashboard.ps1
+++ b/Public/New-LS2Dashboard.ps1
@@ -331,13 +331,22 @@ document.addEventListener('DOMContentLoaded', function() {
         var dt = (window.jQuery && jQuery.fn.DataTable) ? jQuery(table).DataTable() : null;
         if (!dt) return;
         var filter = card.getAttribute('data-filter') || '';
-        var active = card.classList.contains('summary-card-active');
-        section.querySelectorAll('.summary-card').forEach(function(c) { c.classList.remove('summary-card-active'); });
-        if (active || filter === '') {
+        if (filter === '') {
+            section.querySelectorAll('.summary-card').forEach(function(c) { c.classList.remove('summary-card-active'); });
+            dt.column(1).search('').draw();
+            return;
+        }
+        card.classList.toggle('summary-card-active');
+        var activeFilters = [];
+        section.querySelectorAll('.summary-card.summary-card-active').forEach(function(c) {
+            var f = c.getAttribute('data-filter');
+            if (f) { activeFilters.push(f); }
+        });
+        if (activeFilters.length === 0) {
             dt.column(1).search('').draw();
         } else {
-            dt.column(1).search(filter).draw();
-            card.classList.add('summary-card-active');
+            var pattern = activeFilters.map(function(f) { return '^' + f.replace(/[-[\]{}()*+?.,\\\\^$|#\s]/g, '\\\\$&') + '$'; }).join('|');
+            dt.column(1).search(pattern, true, false).draw();
         }
     });
 });

--- a/Tests/Public/New-LS2Dashboard.Tests.ps1
+++ b/Tests/Public/New-LS2Dashboard.Tests.ps1
@@ -51,6 +51,7 @@ InModuleScope 'Locksmith2' {
                 Mock 'New-HTMLTable' { }
                 Mock 'New-HTMLTabStyle' { }
                 Mock 'New-HTMLTableCondition' { }
+                Mock 'New-HTMLTag' { }
                 Mock 'Expand-IssueByGroup' { }
             }
 
@@ -88,6 +89,64 @@ InModuleScope 'Locksmith2' {
             It 'should include a date and time stamp in the dashboard' {
                 New-LS2Dashboard
                 Should -Invoke 'New-HTML' -Times 1 -ParameterFilter { $TitleText -match '\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}' }
+            }
+
+        }
+
+        Context 'Clickable summary cards' -Skip:(-not (Get-Module PSWriteHTML -ListAvailable)) {
+            BeforeEach {
+                Mock 'Get-Command' { [PSCustomObject]@{ Name = 'New-HTML' } } -ParameterFilter { $Name -eq 'New-HTML' }
+                $script:IssueStore = @{
+                    'CN=TestTemplate,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com' = @{
+                        ESC1 = @(
+                            (New-MockLS2Issue -Overrides @{
+                                Technique = 'ESC1'
+                                RiskName  = 'Critical'
+                                Name      = 'CriticalTemplate'
+                            })
+                            (New-MockLS2Issue -Overrides @{
+                                Technique = 'ESC1'
+                                RiskName  = 'High'
+                                Name      = 'HighTemplate'
+                            })
+                        )
+                    }
+                }
+                Mock 'Get-FlattenedIssues' { $script:IssueStore.Values.Values | ForEach-Object { $_ } }
+                Mock 'Find-LS2RiskyPrincipal' { @() }
+                $testFile = Join-Path $TestDrive 'dashboard.html'
+            }
+
+            It 'should render summary cards with click handlers' {
+                New-LS2Dashboard -FilePath $testFile -Show:$false
+                $html = Get-Content -Path $testFile -Raw
+                ($html | Select-String -Pattern 'summary-card' -AllMatches).Matches.Count | Should -BeGreaterThan 0
+                $html | Should -Match 'addEventListener\(''click'''
+            }
+
+            It 'should include a stable table id in the DataTable' {
+                New-LS2Dashboard -FilePath $testFile -Show:$false
+                $html = Get-Content -Path $testFile -Raw
+                $html | Should -Match 'id="IssuesTable-[A-Za-z0-9-]+"'
+            }
+
+            It 'should call DataTables column search on the RiskName column when a card is clicked' {
+                New-LS2Dashboard -FilePath $testFile -Show:$false
+                $html = Get-Content -Path $testFile -Raw
+                $html | Should -Match 'column\(1\)\.search'
+                $html | Should -Match '\.draw\(\)'
+            }
+
+            It 'should clear the filter when Total card or active card is clicked' {
+                New-LS2Dashboard -FilePath $testFile -Show:$false
+                $html = Get-Content -Path $testFile -Raw
+                $html | Should -Match "column\(1\)\.search\(''\)\.draw\(\)"
+            }
+
+            It 'should apply a faded style class to non-selected cards' {
+                New-LS2Dashboard -FilePath $testFile -Show:$false
+                $html = Get-Content -Path $testFile -Raw
+                $html | Should -Match '\.summary-section:has\(\.summary-card-active\) \.summary-card:not\(\.summary-card-active\)'
             }
         }
     }

--- a/Tests/Public/New-LS2Dashboard.Tests.ps1
+++ b/Tests/Public/New-LS2Dashboard.Tests.ps1
@@ -137,10 +137,17 @@ InModuleScope 'Locksmith2' {
                 $html | Should -Match '\.draw\(\)'
             }
 
-            It 'should clear the filter when Total card or active card is clicked' {
+            It 'should clear the filter when Total card is clicked or no severity cards are active' {
                 New-LS2Dashboard -FilePath $testFile -Show:$false
                 $html = Get-Content -Path $testFile -Raw
                 $html | Should -Match "column\(1\)\.search\(''\)\.draw\(\)"
+            }
+
+            It 'should build a regex union pattern for multiple selected severities' {
+                New-LS2Dashboard -FilePath $testFile -Show:$false
+                $html = Get-Content -Path $testFile -Raw
+                $html | Should -Match 'activeFilters\.map'
+                $html | Should -Match "join\('\|'\)"
             }
 
             It 'should apply a faded style class to non-selected cards' {


### PR DESCRIPTION
## Summary

Makes the dashboard summary cards interactive: clicking a severity card filters the tab's issue table by that RiskName, and multiple cards can be toggled to show the union of selected severities. Also changes the default table sort to `RiskValue` descending so the highest-risk issues appear first.

## Changes

- Wrap summary cards in clickable `div` elements with `data-filter` and `data-table-id` attributes
- Add per-tab event delegation script via `Add-HTMLScript` on `DOMContentLoaded`
- Toggle card active state on click; build a regex OR pattern from all active severities
- Clear the filter when the Total card is clicked or the last active severity is toggled off
- Fade non-selected cards via CSS when any card is active
- Default issue tables now sort by `RiskValue` descending
- Add integration tests that generate real HTML and assert on rendered output
- Bump module version to `2026.7.82045`

## Testing

- Full Pester suite passes in both PS 5.1 and PS 7: 2249 passed, 0 failed, 29 skipped
- Manual verification: cards fill section width, hover/click respond, table filters by union of selected severities