### PR TITLE
feat(dashboard): apply RiskValue descending default sort to all issue tabs

### DIFF
--- a/Public/New-LS2Dashboard.ps1
+++ b/Public/New-LS2Dashboard.ps1
@@ -133,14 +133,14 @@
     # Techniques = $null  -> no filter (All Issues).
     # IsPrincipals = $true -> use the principals table and formatting instead of issue table.
     $tabDefs = [ordered]@{
-        'All Issues'        = @{ Icon = 'exclamation-triangle'; IconColor = 'Red';    Techniques = $null;                                                          Subtitle = 'All discovered AD CS vulnerabilities with principals expanded';                                             Title = 'All AD CS Security Issues';           SortColumn = 'Technique'; SummaryLabel = 'Issue' }
-        'Templates'         = @{ Icon = 'file-contract';        IconColor = 'Orange'; Techniques = @('ESC1','ESC2','ESC3c1','ESC3c2','ESC4a','ESC4o','ESC9');      Subtitle = 'Misconfigured templates allowing SAN abuse, weak enrollment restrictions, or enrollment agent exploitation'; Title = 'Template Vulnerabilities';            SortColumn = 'Technique'; SummaryLabel = 'Template Issue' }
-        'CAs'               = @{ Icon = 'certificate';          IconColor = 'Yellow'; Techniques = @('ESC6','ESC7a','ESC7m','ESC8','ESC11','ESC16');               Subtitle = 'Insecure CA configurations and dangerous role assignments (ESC6, ESC7, ESC8, ESC11, ESC16)';             Title = 'CA Configuration Issues';             SortColumn = 'Name';      SummaryLabel = 'CA Issue' }
-        'Objects'           = @{ Icon = 'folder';               IconColor = 'Blue';   Techniques = @('ESC5a','ESC5o');                                             Subtitle = 'Dangerous permissions on PKI infrastructure objects (ESC5)';                                               Title = 'Infrastructure Object Issues';        SortColumn = 'Name';      SummaryLabel = 'Object Issue' }
-        'Risky Principals'  = @{ Icon = 'user-shield';          IconColor = 'Purple'; IsPrincipals = $true;                                                        Subtitle = 'Ranked by number of exploitable AD CS vulnerabilities' }
-        'Dangerous Configurations' = @{ Icon = 'cog';                  IconColor = 'Red';    Techniques = @('ESC1','ESC2','ESC3c1','ESC3c2','ESC6','ESC8','ESC9','ESC11','ESC16'); Subtitle = 'Insecure template/CA configurations enabling certificate abuse (ESC1, ESC2, ESC6, ESC8, ESC9, ESC11, ESC16)'; Title = 'Configuration-Based Vulnerabilities'; SortColumn = 'Technique'; SummaryLabel = 'Configuration Issue' }
-        'Access Control'    = @{ Icon = 'key';                  IconColor = 'Green';  Techniques = @('ESC4a','ESC5a');                                             Subtitle = 'Excessive write/modify permissions on templates and PKI objects (ESC4a, ESC5a)';                            Title = 'Write/Modify Permission Issues';       SortColumn = 'ActiveDirectoryRights'; SummaryLabel = 'Access Control Issue' }
-        'Ownership'         = @{ Icon = 'crown';                IconColor = 'Gold';   Techniques = @('ESC4o','ESC5o');                                             Subtitle = 'Non-standard owners with full control over templates or PKI objects (ESC4o, ESC5o)';                      Title = 'Dangerous Ownership Configurations';   SortColumn = 'Owner';     SummaryLabel = 'Ownership Issue' }
+        'All Issues'        = @{ Icon = 'exclamation-triangle'; IconColor = 'Red';    Techniques = $null;                                                          Subtitle = 'All discovered AD CS vulnerabilities with principals expanded';                                             Title = 'All AD CS Security Issues';           SortColumn = 'RiskValue'; SortOrder = 'Descending'; SummaryLabel = 'Issue' }
+        'Templates'         = @{ Icon = 'file-contract';        IconColor = 'Orange'; Techniques = @('ESC1','ESC2','ESC3c1','ESC3c2','ESC4a','ESC4o','ESC9');      Subtitle = 'Misconfigured templates allowing SAN abuse, weak enrollment restrictions, or enrollment agent exploitation'; Title = 'Template Vulnerabilities';            SortColumn = 'RiskValue'; SortOrder = 'Descending'; SummaryLabel = 'Template Issue' }
+        'CAs'               = @{ Icon = 'certificate';          IconColor = 'Yellow'; Techniques = @('ESC6','ESC7a','ESC7m','ESC8','ESC11','ESC16');               Subtitle = 'Insecure CA configurations and dangerous role assignments (ESC6, ESC7, ESC8, ESC11, ESC16)';             Title = 'CA Configuration Issues';             SortColumn = 'RiskValue'; SortOrder = 'Descending'; SummaryLabel = 'CA Issue' }
+        'Objects'           = @{ Icon = 'folder';               IconColor = 'Blue';   Techniques = @('ESC5a','ESC5o');                                             Subtitle = 'Dangerous permissions on PKI infrastructure objects (ESC5)';                                               Title = 'Infrastructure Object Issues';        SortColumn = 'RiskValue'; SortOrder = 'Descending'; SummaryLabel = 'Object Issue' }
+        'Risky Principals'  = @{ Icon = 'user-shield';          IconColor = 'Purple'; IsPrincipals = $true;                                                        Subtitle = 'Ranked by number of exploitable AD CS vulnerabilities';                                                                                                              SortColumn = 'IssueCount'; SortOrder = 'Descending' }
+        'Dangerous Configurations' = @{ Icon = 'cog';                  IconColor = 'Red';    Techniques = @('ESC1','ESC2','ESC3c1','ESC3c2','ESC6','ESC8','ESC9','ESC11','ESC16'); Subtitle = 'Insecure template/CA configurations enabling certificate abuse (ESC1, ESC2, ESC6, ESC8, ESC9, ESC11, ESC16)'; Title = 'Configuration-Based Vulnerabilities'; SortColumn = 'RiskValue'; SortOrder = 'Descending'; SummaryLabel = 'Configuration Issue' }
+        'Access Control'    = @{ Icon = 'key';                  IconColor = 'Green';  Techniques = @('ESC4a','ESC5a');                                             Subtitle = 'Excessive write/modify permissions on templates and PKI objects (ESC4a, ESC5a)';                            Title = 'Write/Modify Permission Issues';       SortColumn = 'RiskValue'; SortOrder = 'Descending'; SummaryLabel = 'Access Control Issue' }
+        'Ownership'         = @{ Icon = 'crown';                IconColor = 'Gold';   Techniques = @('ESC4o','ESC5o');                                             Subtitle = 'Non-standard owners with full control over templates or PKI objects (ESC4o, ESC5o)';                      Title = 'Dangerous Ownership Configurations';   SortColumn = 'RiskValue'; SortOrder = 'Descending'; SummaryLabel = 'Ownership Issue' }
     }
 
     # Build filtered + projected table for each issue tab
@@ -287,8 +287,8 @@ header img { max-width: 50%; height: auto; display: inline-block; }
                         -PagingLength 25 `
                         -Buttons $tableButtons `
                         -Title 'Principals by Risk Score' `
-                        -DefaultSortColumn 'IssueCount' `
-                        -DefaultSortOrder Descending {& $principalFormatting}
+                        -DefaultSortColumn $def.SortColumn `
+                        -DefaultSortOrder $def.SortOrder {& $principalFormatting}
                     New-HTMLHorizontalLine
                     New-HTMLText -Text "$(@($principalsTable).Count) principals  --  $($def.Subtitle)" -Color '#666' -FontSize 13 -FontStyle italic
                 } else {
@@ -361,8 +361,8 @@ document.addEventListener('DOMContentLoaded', function() {
                         -PagingLength 25 `
                         -Buttons $tableButtons `
                         -Title $def.Title `
-                        -DefaultSortColumn 'RiskValue' `
-                        -DefaultSortOrder Descending {& $issueFormatting}
+                        -DefaultSortColumn $def.SortColumn `
+                        -DefaultSortOrder $def.SortOrder {& $issueFormatting}
                     New-HTMLHorizontalLine
                     New-HTMLText -Text "$($def.Issues.Count) issues  --  $($def.Subtitle)" -Color '#666' -FontSize 13 -FontStyle italic
                 }

--- a/Tests/Public/New-LS2Dashboard.Tests.ps1
+++ b/Tests/Public/New-LS2Dashboard.Tests.ps1
@@ -155,6 +155,30 @@ InModuleScope 'Locksmith2' {
                 $html = Get-Content -Path $testFile -Raw
                 $html | Should -Match '\.summary-section:has\(\.summary-card-active\) \.summary-card:not\(\.summary-card-active\)'
             }
+
+            It 'should default all non-empty issue tabs to RiskValue descending' {
+                New-LS2Dashboard -FilePath $testFile -Show:$false
+                $html = Get-Content -Path $testFile -Raw
+                $issueTableMatches = $html | Select-String -Pattern '\$\(''#IssuesTable-[A-Za-z0-9-]+''\)\.DataTable\(' -AllMatches
+                $issueTableMatches.Matches.Count | Should -BeGreaterThan 0
+                foreach ($match in $issueTableMatches.Matches) {
+                    $startIndex = $match.Index
+                    $endIndex = $html.IndexOf(');', $startIndex)
+                    $initBlock = $html.Substring($startIndex, $endIndex - $startIndex)
+                    # Empty tables omit the order array; only assert on tables that have data.
+                    if ($initBlock -match '"order":\s*\[\s*\d+\s*,\s*"(?:desc|asc)"\s*\]') {
+                        $initBlock | Should -Match '"order":\s*\[\s*2\s*,\s*"desc"\s*\]'
+                    }
+                }
+            }
+
+            It 'should default Risky Principals tab to IssueCount descending' {
+                New-LS2Dashboard -FilePath $testFile -Show:$false
+                $html = Get-Content -Path $testFile -Raw
+                $principalsMatch = $html | Select-String -Pattern 'Principals by Risk Score[\s\S]*?"order":\s*\[\s*(\d+)\s*,\s*"(desc|asc)"\s*\]' -AllMatches
+                $principalsMatch.Matches.Count | Should -BeGreaterThan 0
+                $principalsMatch.Matches[0].Groups[2].Value | Should -Be 'desc'
+            }
         }
     }
 }


### PR DESCRIPTION
- add SortColumn/SortOrder to every $tabDefs entry
- default all issue tabs (All Issues, Templates, CAs, Objects, Dangerous Configurations, Access Control, Ownership) to RiskValue descending
- keep Risky Principals tab sorted by IssueCount descending
- replace hardcoded New-HTMLTable sort params with $def.SortColumn / $def.SortOrder
- add Pester tests asserting default sort order for issue tabs and Risky Principals