### PR TITLE
fix(detection): correct ESC15 and SchemaV1 detection boundaries

### DIFF
--- a/Private/Data/ESCDefinitions.ps1
+++ b/Private/Data/ESCDefinitions.ps1
@@ -713,14 +713,14 @@ $script:ESCDefinitions = data {
         }
 
         ESC15  = @{
-            # ESC15: Schema v1 template with auth EKU — bypasses strong certificate mapping
+            # ESC15: Enabled schema v1 template with auth EKU — bypasses strong certificate mapping
             # (szOID_NTDS_CA_SECURITY_EXT is absent in schema v1 certificates)
             Technique          = 'ESC15'
 
             Conditions         = @(
                 @{ Property = 'TemplateSchemaVersion'; Value = 1 }
                 @{ Property = 'AuthenticationEKUExist'; Value = $true }
-                @{ Property = 'ManagerApprovalNotRequired'; Value = $true }
+                @{ Property = 'Enabled'; Value = $true }
                 @{ Property = 'AuthorizedSignatureNotRequired'; Value = $true }
             )
 
@@ -730,30 +730,28 @@ $script:ESCDefinitions = data {
             )
 
             IssueTemplate      = @(
-                "`$(IdentityReference) can enroll in the `$(TemplateName) template, which uses a schema version 1 "
+                "`$(IdentityReference) can enroll in the `$(TemplateName) template, which uses schema version 1 "
                 "and a Client Authentication EKU.`n`n"
                 "Schema v1 templates do not include the CA security extension (szOID_NTDS_CA_SECURITY_EXT) "
                 "introduced by KB5014754. This means certificates issued from this template are not subject to "
                 "strong certificate-to-account mapping enforcement, allowing an attacker to authenticate as any "
                 "principal whose UPN or DNS name they can include in the Subject or SAN of the certificate.`n`n"
-                "Until the template is upgraded to schema v2+, enabling Manager Approval is the recommended "
-                "short-term mitigation to prevent unapproved enrollment.`n`n"
+                "Schema v1 templates cannot be modified in place. Supersede this template with a schema v2+ "
+                "equivalent, or remove the Client Authentication EKU if it is not required.`n`n"
                 "More info:`n"
                 "  - https://support.microsoft.com/help/5014754"
             )
 
             FixTemplate        = @(
-                "# Quick mitigation: Enable Manager Approval to require approval before certificate issuance"
-                "`$Object = '`$(DistinguishedName)'"
-                "Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 2}"
-                "# Long-term fix: supersede this template with a schema v2+ equivalent"
+                "# Schema v1 templates cannot be modifieed in-place."
+                "# Supersede this template by creating a new schema v2 (or later) template with equivalent settings,"
+                "# then configure the old template to be superseded by the new one."
                 "# See: https://www.gradenegger.eu/en/basics-replace-superseding-of-certificate-templates/"
             )
 
             RevertTemplate     = @(
-                "# Disable Manager Approval"
-                "`$Object = '`$(DistinguishedName)'"
-                "Get-ADObject `$Object | Set-ADObject -Replace @{'msPKI-Enrollment-Flag' = 0}"
+                "# No automated revert. Template schema version cannot be changed via script."
+                "# If you superseded this template, re-enable the old template and remove the superseding relationship."
             )
         }
 
@@ -790,12 +788,13 @@ $script:ESCDefinitions = data {
         }
 
         SchemaV1 = @{
-            # SchemaV1: Any enabled schema v1 template — informational hygiene finding
+            # SchemaV1: Enabled schema v1 template without client auth EKU — informational hygiene finding
             Technique      = 'SchemaV1'
 
             Conditions     = @(
                 @{ Property = 'TemplateSchemaVersion'; Value = 1 }
                 @{ Property = 'Enabled'; Value = $true }
+                @{ Property = 'AuthenticationEKUExist'; Value = $false }
             )
 
             IssueTemplate  = @(
@@ -804,7 +803,9 @@ $script:ESCDefinitions = data {
                 "available in later schema versions. Certificates issued from schema v1 templates do not "
                 "include the CA security extension (szOID_NTDS_CA_SECURITY_EXT), reducing their compatibility "
                 "with strong certificate mapping requirements.`n`n"
-                "Consider superseding this template with a schema v2+ equivalent."
+                "Because this template does not include a Client Authentication EKU, it is not directly "
+                "exploitable for account takeover via ESC15. However, it should still be superseded with a "
+                "schema v2+ equivalent to ensure compatibility with modern security features."
             )
 
             FixTemplate    = @(

--- a/Private/Data/ESCDefinitions.ps1
+++ b/Private/Data/ESCDefinitions.ps1
@@ -737,21 +737,21 @@ $script:ESCDefinitions = data {
                 "strong certificate-to-account mapping enforcement, allowing an attacker to authenticate as any "
                 "principal whose UPN or DNS name they can include in the Subject or SAN of the certificate.`n`n"
                 "Schema v1 templates cannot be modified in place. Supersede this template with a schema v2+ "
-                "equivalent, or remove the Client Authentication EKU if it is not required.`n`n"
+                "equivalent.`n`n"
                 "More info:`n"
                 "  - https://support.microsoft.com/help/5014754"
             )
 
             FixTemplate        = @(
-                "# Schema v1 templates cannot be modifieed in-place."
-                "# Supersede this template by creating a new schema v2 (or later) template with equivalent settings,"
-                "# then configure the old template to be superseded by the new one."
-                "# See: https://www.gradenegger.eu/en/basics-replace-superseding-of-certificate-templates/"
+                '# Schema v1 templates cannot be upgraded in-place.'
+                '# Supersede this template by creating a new schema v2 (or later) template with equivalent settings,'
+                '# then configure the old template to be superseded by the new one.'
+                '# See: https://www.gradenegger.eu/en/basics-replace-superseding-of-certificate-templates/'
             )
 
             RevertTemplate     = @(
-                "# No automated revert. Template schema version cannot be changed via script."
-                "# If you superseded this template, re-enable the old template and remove the superseding relationship."
+                '# No automated revert. Template schema version cannot be changed via script.'
+                '# If you superseded this template, re-enable the old template and remove the superseding relationship.'
             )
         }
 

--- a/Tests/Public/Find-LS2VulnerableTemplate.Tests.ps1
+++ b/Tests/Public/Find-LS2VulnerableTemplate.Tests.ps1
@@ -25,7 +25,6 @@ InModuleScope 'Locksmith2' {
                     SchemaClassName                = 'pKICertificateTemplate'
                     SANAllowed                     = $true
                     AuthenticationEKUExist         = $true
-                    ManagerApprovalNotRequired     = $true
                     AuthorizedSignatureNotRequired = $true
                     DangerousEnrollee              = @('S-1-1-0')
                     distinguishedName              = 'CN=VulnTemplate,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
@@ -112,9 +111,9 @@ InModuleScope 'Locksmith2' {
 
             It 'should skip a template where any ESC1 condition is not met' {
                 $safeTemplate = New-MockLS2AdcsObject -Properties @{
-                    SANAllowed            = $false
-                    distinguishedName     = 'CN=SafeTemplate,CN=Certificate Templates,...'
-                    Name                  = 'SafeTemplate'
+                    SANAllowed        = $false
+                    distinguishedName = 'CN=SafeTemplate,CN=Certificate Templates,...'
+                    Name              = 'SafeTemplate'
                 }
                 $script:AdcsObjectStore = @{ $safeTemplate.distinguishedName = $safeTemplate }
                 $result = @(Find-LS2VulnerableTemplate -Technique 'ESC1')
@@ -173,16 +172,16 @@ InModuleScope 'Locksmith2' {
             BeforeAll {
                 function script:New-ESC13VulnerableTemplate {
                     $t = New-MockLS2AdcsObject -Properties @{
-                        objectClass              = @('top', 'pKICertificateTemplate')
-                        SchemaClassName          = 'pKICertificateTemplate'
-                        AuthenticationEKUExist   = $true
-                        HasLinkedGroupOIDPolicy  = $true
-                        LinkedGroupOIDPolicies   = @('CN=PrivilegedGroup,CN=Users,DC=contoso,DC=com')
-                        DangerousEnrollee        = @('S-1-1-0')
-                        distinguishedName        = 'CN=ESC13Template,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
-                        Name                     = 'ESC13Template'
-                        Enabled                  = $true
-                        EnabledOn                = @('CONTOSO-CA\CA01')
+                        objectClass             = @('top', 'pKICertificateTemplate')
+                        SchemaClassName         = 'pKICertificateTemplate'
+                        AuthenticationEKUExist  = $true
+                        HasLinkedGroupOIDPolicy = $true
+                        LinkedGroupOIDPolicies  = @('CN=PrivilegedGroup,CN=Users,DC=contoso,DC=com')
+                        DangerousEnrollee       = @('S-1-1-0')
+                        distinguishedName       = 'CN=ESC13Template,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
+                        Name                    = 'ESC13Template'
+                        Enabled                 = $true
+                        EnabledOn               = @('CONTOSO-CA\CA01')
                     }
                     $security = New-Object System.DirectoryServices.ActiveDirectorySecurity
                     $sid = [System.Security.Principal.SecurityIdentifier]::new('S-1-1-0')
@@ -267,14 +266,14 @@ InModuleScope 'Locksmith2' {
 
             It 'should not return an issue when DangerousEnrollee is empty' {
                 $safeTemplate = New-MockLS2AdcsObject -Properties @{
-                    SchemaClassName          = 'pKICertificateTemplate'
-                    AuthenticationEKUExist   = $true
-                    HasLinkedGroupOIDPolicy  = $true
-                    LinkedGroupOIDPolicies   = @('CN=PrivilegedGroup,CN=Users,DC=contoso,DC=com')
-                    DangerousEnrollee        = @()
-                    LowPrivilegeEnrollee     = @()
-                    distinguishedName        = 'CN=SafeTemplate,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
-                    Name                     = 'SafeTemplate'
+                    SchemaClassName         = 'pKICertificateTemplate'
+                    AuthenticationEKUExist  = $true
+                    HasLinkedGroupOIDPolicy = $true
+                    LinkedGroupOIDPolicies  = @('CN=PrivilegedGroup,CN=Users,DC=contoso,DC=com')
+                    DangerousEnrollee       = @()
+                    LowPrivilegeEnrollee    = @()
+                    distinguishedName       = 'CN=SafeTemplate,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
+                    Name                    = 'SafeTemplate'
                 }
                 $script:AdcsObjectStore = @{ $safeTemplate.distinguishedName = $safeTemplate }
 
@@ -330,7 +329,7 @@ InModuleScope 'Locksmith2' {
                 Mock 'Test-IssueExists' { $false }
             }
 
-            It 'should return an LS2Issue when template has TemplateSchemaVersion=1, auth EKU, no manager approval, and DangerousEnrollee' {
+            It 'should return an LS2Issue when template has TemplateSchemaVersion=1, auth EKU, is Enabled, AuthorizedSignatureNotRequired, and DangerousEnrollee' {
                 $vulnTemplate = New-ESC15VulnerableTemplate
                 $script:AdcsObjectStore = @{ $vulnTemplate.distinguishedName = $vulnTemplate }
 
@@ -354,9 +353,9 @@ InModuleScope 'Locksmith2' {
                     SchemaClassName                = 'pKICertificateTemplate'
                     TemplateSchemaVersion          = 2
                     AuthenticationEKUExist         = $true
-                    ManagerApprovalNotRequired     = $true
                     AuthorizedSignatureNotRequired = $true
                     DangerousEnrollee              = @('S-1-1-0')
+                    Enabled                        = $true
                     distinguishedName              = 'CN=SafeTemplate,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
                     Name                           = 'SafeTemplate'
                 }
@@ -372,9 +371,27 @@ InModuleScope 'Locksmith2' {
                     SchemaClassName                = 'pKICertificateTemplate'
                     TemplateSchemaVersion          = 1
                     AuthenticationEKUExist         = $false
-                    ManagerApprovalNotRequired     = $true
                     AuthorizedSignatureNotRequired = $true
                     DangerousEnrollee              = @('S-1-1-0')
+                    Enabled                        = $true
+                    distinguishedName              = 'CN=SafeTemplate,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
+                    Name                           = 'SafeTemplate'
+                }
+                $script:AdcsObjectStore = @{ $safeTemplate.distinguishedName = $safeTemplate }
+
+                $result = @(Find-LS2VulnerableTemplate -Technique 'ESC15')
+
+                $result.Count | Should -Be 0
+            }
+
+            It 'should not return an issue when Enabled is false' {
+                $safeTemplate = New-MockLS2AdcsObject -Properties @{
+                    SchemaClassName                = 'pKICertificateTemplate'
+                    TemplateSchemaVersion          = 1
+                    AuthenticationEKUExist         = $true
+                    AuthorizedSignatureNotRequired = $true
+                    DangerousEnrollee              = @('S-1-1-0')
+                    Enabled                        = $false
                     distinguishedName              = 'CN=SafeTemplate,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
                     Name                           = 'SafeTemplate'
                 }
@@ -391,13 +408,14 @@ InModuleScope 'Locksmith2' {
                 Mock 'Test-IssueExists' { $false }
             }
 
-            It 'should return an LS2Issue for any enabled schema v1 template' {
+            It 'should return an LS2Issue for any enabled schema v1 template without client auth EKU' {
                 $template = New-MockLS2AdcsObject -Properties @{
-                    SchemaClassName       = 'pKICertificateTemplate'
-                    TemplateSchemaVersion = 1
-                    Enabled               = $true
-                    distinguishedName     = 'CN=SchemaV1Template,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
-                    Name                  = 'SchemaV1Template'
+                    SchemaClassName        = 'pKICertificateTemplate'
+                    TemplateSchemaVersion  = 1
+                    Enabled                = $true
+                    AuthenticationEKUExist = $false
+                    distinguishedName      = 'CN=SchemaV1Template,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
+                    Name                   = 'SchemaV1Template'
                 }
                 $script:AdcsObjectStore = @{ $template.distinguishedName = $template }
 
@@ -409,17 +427,34 @@ InModuleScope 'Locksmith2' {
 
             It 'should return an issue with Technique SchemaV1' {
                 $template = New-MockLS2AdcsObject -Properties @{
-                    SchemaClassName       = 'pKICertificateTemplate'
-                    TemplateSchemaVersion = 1
-                    Enabled               = $true
-                    distinguishedName     = 'CN=SchemaV1Template,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
-                    Name                  = 'SchemaV1Template'
+                    SchemaClassName        = 'pKICertificateTemplate'
+                    TemplateSchemaVersion  = 1
+                    Enabled                = $true
+                    AuthenticationEKUExist = $false
+                    distinguishedName      = 'CN=SchemaV1Template,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
+                    Name                   = 'SchemaV1Template'
                 }
                 $script:AdcsObjectStore = @{ $template.distinguishedName = $template }
 
                 $result = @(Find-LS2VulnerableTemplate -Technique 'SchemaV1')
 
                 $result[0].Technique | Should -Be 'SchemaV1'
+            }
+
+            It 'should not return an issue when AuthenticationEKUExist is true' {
+                $safeTemplate = New-MockLS2AdcsObject -Properties @{
+                    SchemaClassName        = 'pKICertificateTemplate'
+                    TemplateSchemaVersion  = 1
+                    Enabled                = $true
+                    AuthenticationEKUExist = $true
+                    distinguishedName      = 'CN=AuthEKUTemplate,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'
+                    Name                   = 'AuthEKUTemplate'
+                }
+                $script:AdcsObjectStore = @{ $safeTemplate.distinguishedName = $safeTemplate }
+
+                $result = @(Find-LS2VulnerableTemplate -Technique 'SchemaV1')
+
+                $result.Count | Should -Be 0
             }
 
             It 'should not return an issue when TemplateSchemaVersion is 2' {

--- a/Tests/Public/Find-LS2VulnerableTemplate.Tests.ps1
+++ b/Tests/Public/Find-LS2VulnerableTemplate.Tests.ps1
@@ -300,7 +300,6 @@ InModuleScope 'Locksmith2' {
                         SchemaClassName                = 'pKICertificateTemplate'
                         TemplateSchemaVersion          = 1
                         AuthenticationEKUExist         = $true
-                        ManagerApprovalNotRequired     = $true
                         AuthorizedSignatureNotRequired = $true
                         DangerousEnrollee              = @('S-1-1-0')
                         distinguishedName              = 'CN=ESC15Template,CN=Certificate Templates,CN=Public Key Services,CN=Services,CN=Configuration,DC=contoso,DC=com'


### PR DESCRIPTION
## Summary

This change separates the concerns of the ESC15 and SchemaV1 findings and fixes an incorrect mitigation recommendation.

- **ESC15** now correctly identifies *exploitable* schema v1 templates: enabled, with a Client Authentication EKU, and no authorized-signature requirement.
- **SchemaV1** now identifies enabled schema v1 templates that do *not* have a Client Authentication EKU, as an informational hygiene finding.

## Key changes

- `Private/Data/ESCDefinitions.ps1`
  - Removed `ManagerApprovalNotRequired` from ESC15 conditions. Schema v1 templates do not support manager approval; only permissions can be modified on them.
  - Added `Enabled = $true` to ESC15 conditions.
  - Replaced ESC15's `FixTemplate`/`RevertTemplate` with supersede guidance, matching SchemaV1.
  - Added `AuthenticationEKUExist = $false` to SchemaV1 conditions so ESC15 and SchemaV1 are mutually exclusive.
  - Removed incorrect "remove the Client Authentication EKU" advice from ESC15 issue text.

- `Tests/Public/Find-LS2VulnerableTemplate.Tests.ps1`
  - Updated ESC15 mock to no longer set `ManagerApprovalNotRequired`.
  - Added negative tests for `Enabled = $false` (ESC15) and `AuthenticationEKUExist = $true` (SchemaV1).

## Verification

- `ESCDefinitions.Tests.ps1` passes (structure/keys/scoring).
- `Find-LS2VulnerableTemplate.Tests.ps1` runs; failures on macOS are due to `System.DirectoryServices.ActiveDirectorySecurity` being Windows-only, unrelated to this change.

## Related context

- Microsoft Learn: [Certificate template concepts](https://learn.microsoft.com/windows-server/identity/ad-cs/certificate-template-concepts)