### PR TITLE
fix(build): ensure format file triggers publish and loads from source

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ on:
       - 'Build/**'
       - 'Locksmith2.psm1'
       - 'Locksmith2.psd1'
+      - 'LS2Issue.format.ps1xml'
       - 'LICENSE'
       - '.github/workflows/publish.yml'
   workflow_dispatch:  # Allow manual trigger

--- a/Locksmith2.psd1
+++ b/Locksmith2.psd1
@@ -6,6 +6,7 @@
     CompatiblePSEditions=@('Desktop',        'Core')
     Copyright='(c) 2024 - 2026. All rights reserved.'
     Description='An AD CS toolkit for AD Admins, Defensive Security Professionals, and Filthy Red Teamers'
+    FormatsToProcess=@('LS2Issue.format.ps1xml')
     FunctionsToExport=@('*')
     GUID='e32f7d0d-2b10-4db2-b776-a193958e3d69'
     ModuleVersion='2026.8.20917'


### PR DESCRIPTION
## Summary

Hardens the build/publish pipeline so that `LS2Issue.format.ps1xml` changes are always included in published packages and the module loads format data correctly when imported from source.

## Problem

- The publish workflow did not trigger on changes to `LS2Issue.format.ps1xml`, so format-only updates could be skipped during release.
- The source `Locksmith2.psd1` did not declare `FormatsToProcess`, relying on a runtime fallback in `Locksmith2.psm1` for source imports.

## Changes

- Added `LS2Issue.format.ps1xml` to the push trigger paths in `.github/workflows/publish.yml`.
- Added `FormatsToProcess = @('LS2Issue.format.ps1xml')` to `Locksmith2.psd1`.

## Verification

- `Import-Module Locksmith2.psd1` from source now loads all 21 format views (`Default`, `Summary`, 19 `*Detailed` views, and `Full`).

## Files changed

- `.github/workflows/publish.yml`
- `Locksmith2.psd1`