### PR TITLE
chore(version): bump module version to 2026.8.30507

### DIFF
--- a/Locksmith2.psd1
+++ b/Locksmith2.psd1
@@ -9,7 +9,7 @@
     FormatsToProcess=@('LS2Issue.format.ps1xml')
     FunctionsToExport=@('*')
     GUID='e32f7d0d-2b10-4db2-b776-a193958e3d69'
-    ModuleVersion='2026.8.20917'
+    ModuleVersion='2026.8.30507'
     PowerShellVersion='5.1'
     PrivateData=@{
         PSData=@{


### PR DESCRIPTION
## Summary

Bumps the module version to the current CalVer timestamp.

## Changes

- `Locksmith2.psd1`: `ModuleVersion` updated from `2026.8.20917` to `2026.8.30507`.

## Files changed

- `Locksmith2.psd1`