### PR TITLE
fix(detection): tri-state certutil-backed CA properties so query failure is not a finding

### DIFF
--- a/.scratch/auditfilter-query-failure-fp/spec.md
+++ b/.scratch/auditfilter-query-failure-fp/spec.md
@@ -1,0 +1,55 @@
+# AuditFilter Query Failure False Positive
+
+Status: implemented (2026-08-20), pending PS 5.1 test run on Windows
+
+GitHub: [#92 — AuditFilter detection Possible Bug](https://github.com/jakehildreth/Locksmith2/issues/92) (raised by @thedxt)
+
+## Destination
+
+Locksmith2 distinguishes "auditing is disabled/incomplete" from "could not determine auditing state." When the AuditFilter query fails (certutil error, CA unreachable, RPC blocked, permissions), the `Auditing` technique must not fire, and the user should be able to tell the query failed rather than infer auditing is fine.
+
+## Notes
+
+- Domain: `Private/Set/Set-CAAuditFilter.ps1` (queries AuditFilter via PSCertutil's `Get-PSCAuditFilter`), `Classes/LS2AdcsObject.ps1` (`[Nullable[int]]$AuditFilter`, `[bool]$AuditingIncomplete`), `Private/Data/ESCDefinitions.ps1` (`Auditing` technique, condition `AuditingIncomplete -eq $true`).
+- Failure modes in `Set-CAAuditFilter` today, all silent (Verbose only):
+  - `Get-PSCAuditFilter` throws → caught, property untouched.
+  - Returns `$null` or object without `AuditFilter` → skipped.
+  - No `CAFullName` on the object → skipped.
+- `AuditingIncomplete` is non-nullable `[bool]` on the class, so "never queried" and "queried, auditing fine" share one value (`$false`). The detection condition cannot distinguish failure from clean.
+- Reporter's symptom implies `AuditingIncomplete` ends up `$true` on query failure in their environment; needs a repro trace to find which path sets it (stale store value, partial read, or upstream default). Regardless of the exact trigger, the missing tri-state is the root design gap.
+- **Root cause found 2026-08-21 (in PSCertutil, not Locksmith2):** `parseAuditFilter` (PSCertutil 0.0.3) on certutil failure ran `[int]$AuditFilter = $null`, which coerces to `0`, then always emitted `@{ AuditFilter = 0 }`. A failed query returned a truthy object with a real `0`, so `Set-CAAuditFilter` computed `AuditingIncomplete = (0 -ne 127) = $true` → "auditing not enabled" finding. That is @thedxt's exact repro. Fixed in PSCertutil branch `fix/auditfilter-parse-failure` (emit nothing on parse failure). The Locksmith2 tri-state change in this spec remains correct as defense-in-depth: even with a fixed parser, a thrown/empty result must not leave a stale or default-clean value.
+
+## Decisions so far
+
+- **Root cause (confirmed by mock repro):** `AuditingIncomplete` was the only one of the four certutil-backed detection properties declared non-nullable `[bool]`. Query failure left `$false`, indistinguishable from "queried, auditing complete." The other three (`SANFlagEnabled`, `RPCEncryptionNotRequired`, `SecurityExtensionDisabled`) were already `[Nullable[bool]]`.
+- **Tri-state shape:** `[Nullable[bool]]`, `$null` = unknown/never queried. Matches existing class conventions (`ManagerApprovalNotRequired`, `AuthorizedSignatureNotRequired`, `SecurityExtensionDisabled`). No companion `*Queried` flag — `$null` carries the signal.
+- **Detection condition unchanged:** the generic evaluator (`Find-LS2VulnerableCA.ps1`, `$propertyValue -ne $condition.Value`) already fails to match `$null -eq $true`, so `ESCDefinitions.ps1` needed no edit. Verified by a new Find-level test: CA with `AuditingIncomplete = $null` emits no `Auditing` issue.
+- **Failure paths set `$null` explicitly** (not just "leave untouched") in all four cmdlets, so a stale value from a rescan cannot survive a failed query.
+- **`Set-CADisableExtensionList` catch block was broken independently:** inside `catch`, `$_` is the ErrorRecord, so `$_.DisableExtensionList = $null` threw on the ErrorRecord. The catch had never worked. Fixed by capturing the CA object in `$caObject` before the try — the pattern the other three cmdlets already used; those three were also converted from `$_` to `$caObject` inside try/catch for the same latent reason.
+- **Failed query stays silent** (Verbose only) — no new informational finding type. The fix is that failure ≠ finding; surfacing "couldn't check CA X" to the user is a possible follow-up, not required by #92.
+- **ESC11 semantics preserved:** `IF_ENFORCEENCRYPTICERTREQUEST` absent from a *successful* InterfaceFlags result still yields `RPCEncryptionNotRequired = $true` (flag genuinely not set on the CA). Only query failure yields `$null`.
+
+## Not yet specified
+
+_Nothing — implemented 2026-08-20._
+
+## Out of scope
+
+- Changes to the `Auditing` IssueTemplate/FixTemplate wording.
+- ~~PSCertutil module changes.~~ (Superseded 2026-08-21: the true root cause was PSCertutil's `parseAuditFilter` fabricating `0` on failure. Fixed in PSCertutil branch `fix/auditfilter-parse-failure`; kept out of this repo's change set.)
+- Surfacing query failures as informational findings. (Note: the `$null` state is observable only via `-Verbose` after this change. The spec Destination's "the user should be able to tell the query failed" is satisfied only at Verbose level; a visible "unknown" surface — warning, dashboard state, or informational finding — remains possible follow-up work, deliberately not in this fix. Issue #92 itself requires only that failure not be reported as a finding, which is satisfied.)
+
+### Original scope boundary (recorded before implementation, preserved for history)
+
+The pre-implementation version of this section read: "Changes to other certutil-backed `Set-CA*` functions with the same try/catch-silent pattern (`Set-CAEditFlags`, `Set-CAInterfaceFlags`, `Set-CADisableExtensionList`) — same design gap may exist there, but fix separately." The user then directed fixing all four cmdlets in one change, superseding that boundary; investigation confirmed the same defect class in all four (and a broken catch block in `Set-CADisableExtensionList`), making the combined fix one logical change.
+
+## Implementation (2026-08-20)
+
+- `Classes/LS2AdcsObject.ps1` — `AuditingIncomplete` → `[Nullable[bool]]`.
+- `Private/Set/Set-CAAuditFilter.ps1` — `$null` on throw and empty-result paths.
+- `Private/Set/Set-CAEditFlags.ps1` — `$null` on throw and empty-result paths.
+- `Private/Set/Set-CAInterfaceFlags.ps1` — `$null` on throw and empty-result paths.
+- `Private/Set/Set-CADisableExtensionList.ps1` — fixed `$_`-is-ErrorRecord catch bug; `$null` on throw path.
+- `Tests/Shared/TestHelpers.psm1` — mock default `AuditingIncomplete = $null`.
+- Tests added: failure-path (throw + null-result) contexts in all four `Set-CA*` test files; PSCertutil stub added to `Set-CADisableExtensionList.Tests.ps1`; Find-level `$null` regression test in `Find-LS2VulnerableCA.Tests.ps1`.
+- Verified: 56/56 targeted tests pass in pwsh 7.6.5; full suite 2138/238-fail where the 238 are pre-existing macOS platform failures identical on unmodified `main` (no `System.DirectoryServices`/`Get-CimInstance`/Windows Principal APIs). PS 5.1 leg **not run locally** (no `powershell.exe` on macOS) — must be run on Windows before merge.

--- a/Classes/LS2AdcsObject.ps1
+++ b/Classes/LS2AdcsObject.ps1
@@ -67,7 +67,7 @@
     [Nullable[bool]]$SANFlagEnabled
     [object[]]$InterfaceFlags
     [Nullable[int]]$AuditFilter
-    [bool]$AuditingIncomplete
+    [Nullable[bool]]$AuditingIncomplete
     [object[]]$DisableExtensionList
     [Nullable[bool]]$SecurityExtensionDisabled
     [object[]]$WebEnrollmentEndpoints

--- a/Private/Set/Set-CAAuditFilter.ps1
+++ b/Private/Set/Set-CAAuditFilter.ps1
@@ -78,24 +78,31 @@
                 
                 Write-Verbose "  Querying AuditFilter for: $caFullName"
                 
+                $caObject = $_
                 try {
                     # Query AuditFilter using PSCertutil
                     $auditFilterResult = Get-PSCAuditFilter -CAFullName $caFullName -ErrorAction Stop
-                    
+
                     if ($auditFilterResult -and $null -ne $auditFilterResult.AuditFilter) {
                         $auditFilter = $auditFilterResult.AuditFilter
                         Write-Verbose "  Retrieved AuditFilter: $auditFilter"
-                        
+
                         # Set the property directly on the LS2AdcsObject (same reference as store)
-                        $_.AuditFilter = $auditFilter
-                        $_.AuditingIncomplete = ($auditFilter -ne 127)
-                        Write-Verbose "  Updated $($_.distinguishedName) with AuditFilter data (AuditingIncomplete=$($_.AuditingIncomplete))"
-                        
+                        $caObject.AuditFilter = $auditFilter
+                        $caObject.AuditingIncomplete = ($auditFilter -ne 127)
+                        Write-Verbose "  Updated $($caObject.distinguishedName) with AuditFilter data (AuditingIncomplete=$($caObject.AuditingIncomplete))"
+
                     } else {
                         Write-Verbose "  No AuditFilter returned from Get-PSCAuditFilter"
+                        # Unknown state: leave tri-state properties $null so detection does not treat failure as clean (GH #92)
+                        $caObject.AuditFilter = $null
+                        $caObject.AuditingIncomplete = $null
                     }
                 } catch {
                     Write-Verbose "  Failed to query AuditFilter for '$caFullName': $($_.Exception.Message)"
+                    # Unknown state: leave tri-state properties $null so detection does not treat failure as clean (GH #92)
+                    $caObject.AuditFilter = $null
+                    $caObject.AuditingIncomplete = $null
                 }
             } catch {
                 Write-Warning "Error processing CA: $($_.Exception.Message)"

--- a/Private/Set/Set-CADisableExtensionList.ps1
+++ b/Private/Set/Set-CADisableExtensionList.ps1
@@ -43,16 +43,17 @@
 
     process {
         $AdcsObject | Where-Object { $_.IsCertificationAuthority() } | ForEach-Object {
+            $caObject = $_
             try {
-                $caName = $_.cn
+                $caName = $caObject.cn
                 Write-Verbose "Processing CA: $caName"
-                
-                $dn = $_.distinguishedName
 
-                $caFullName = $_.CAFullName
+                $dn = $caObject.distinguishedName
+
+                $caFullName = $caObject.CAFullName
                 if ([string]::IsNullOrEmpty($caFullName)) {
                     Write-Warning "CAFullName is empty for CA: $dn"
-                    $_
+                    $caObject
                     return
                 }
 
@@ -60,7 +61,7 @@
 
                 # Query DisableExtensionList using PSCertutil
                 $disableExtensionListResult = Get-PSCDisableExtensionList -CAFullName $caFullName -ErrorAction Stop
-                
+
                 # Get-PSCDisableExtensionList returns an array of objects with DisabledExtension property
                 # or $null if no extensions are disabled
                 # Force array wrapping with @() for PS 5.1 compatibility (.Count on single objects)
@@ -68,38 +69,38 @@
                     # Extract the extension OIDs/names into an array
                     $disabledExtensions = $disableExtensionListResult | ForEach-Object { $_.DisabledExtension }
                     Write-Verbose "  Retrieved $($disabledExtensions.Count) disabled extension(s): $($disabledExtensions -join ', ')"
-                    
+
                     # Check if the Microsoft Certificate Template Information extension is disabled
                     # OID: 1.3.6.1.4.1.311.25.2 (szOID_CERTIFICATE_TEMPLATE)
                     $securityExtensionDisabled = $disabledExtensions -contains '1.3.6.1.4.1.311.25.2'
-                    
+
                     if ($securityExtensionDisabled) {
                         Write-Verbose "  CRITICAL: Security extension (1.3.6.1.4.1.311.25.2) is DISABLED"
                     } else {
                         Write-Verbose "  Security extension (1.3.6.1.4.1.311.25.2) is enabled"
                     }
-                    
+
                     # Set properties directly on the LS2AdcsObject (same reference as store)
-                    $_.DisableExtensionList = $disabledExtensions
-                    $_.SecurityExtensionDisabled = $securityExtensionDisabled
-                    Write-Verbose "  Updated $($_.distinguishedName) with DisableExtensionList and SecurityExtensionDisabled"
+                    $caObject.DisableExtensionList = $disabledExtensions
+                    $caObject.SecurityExtensionDisabled = $securityExtensionDisabled
+                    Write-Verbose "  Updated $($caObject.distinguishedName) with DisableExtensionList and SecurityExtensionDisabled"
                 } else {
                     # No extensions disabled - set directly
                     Write-Verbose "  No extensions disabled on this CA"
-                    $_.DisableExtensionList = @()
-                    $_.SecurityExtensionDisabled = $false
-                    Write-Verbose "  Updated $($_.distinguishedName) with empty DisableExtensionList"
+                    $caObject.DisableExtensionList = @()
+                    $caObject.SecurityExtensionDisabled = $false
+                    Write-Verbose "  Updated $($caObject.distinguishedName) with empty DisableExtensionList"
                 }
             } catch {
                 Write-Verbose "  Failed to query DisableExtensionList for '$caFullName': $($_.Exception.Message)"
-                
-                # Set to null on error
-                $_.DisableExtensionList = $null
-                $_.SecurityExtensionDisabled = $null
+
+                # Unknown state: leave tri-state properties $null so detection does not treat failure as clean
+                $caObject.DisableExtensionList = $null
+                $caObject.SecurityExtensionDisabled = $null
             }
-            
+
             # Always return the object to continue the pipeline
-            $_
+            $caObject
         }
     }
 

--- a/Private/Set/Set-CAEditFlags.ps1
+++ b/Private/Set/Set-CAEditFlags.ps1
@@ -1,4 +1,4 @@
-﻿function Set-CAEditFlags {
+function Set-CAEditFlags {
     <#
         .SYNOPSIS
         Adds EditFlags configuration properties to AD CS Certification Authority objects.
@@ -77,31 +77,38 @@
                 }
                 
                 Write-Verbose "  Querying EditFlags for: $caFullName"
-                
+
+                $caObject = $_
                 try {
                     # Query EditFlags using PSCertutil
                     $editFlags = Get-PSCEditFlag -CAFullName $caFullName -ErrorAction Stop
-                    
+
                     if ($editFlags) {
                         Write-Verbose "  Retrieved $(@($editFlags).Count) EditFlags"
-                        
+
                         # Check specifically for EDITF_ATTRIBUTESUBJECTALTNAME2
                         $sANFlag = $editFlags | Where-Object { $_.EditFlag -eq 'EDITF_ATTRIBUTESUBJECTALTNAME2' }
                         $sANFlagEnabled = if ($sANFlag) { $sANFlag.Enabled } else { $false }
-                        
+
                         Write-Verbose "  EDITF_ATTRIBUTESUBJECTALTNAME2 is $(if ($sANFlagEnabled) { 'enabled' } else { 'disabled' })"
-                        
+
                         # Set properties directly on the LS2AdcsObject (same reference as store)
-                        $_.EditFlags = $editFlags
-                        $_.SANFlagEnabled = $sANFlagEnabled
-                        Write-Verbose "  Updated $($_.distinguishedName) with EditFlags data"
-                        
+                        $caObject.EditFlags = $editFlags
+                        $caObject.SANFlagEnabled = $sANFlagEnabled
+                        Write-Verbose "  Updated $($caObject.distinguishedName) with EditFlags data"
+
                     } else {
                         Write-Verbose "  No EditFlags returned from Get-PSCEditFlag"
+                        # Unknown state: leave tri-state properties $null so detection does not treat failure as clean
+                        $caObject.EditFlags = $null
+                        $caObject.SANFlagEnabled = $null
                     }
-                    
+
                 } catch {
                     Write-Verbose "  Failed to query EditFlags for '$caFullName': $($_.Exception.Message)"
+                    # Unknown state: leave tri-state properties $null so detection does not treat failure as clean
+                    $caObject.EditFlags = $null
+                    $caObject.SANFlagEnabled = $null
                     # Continue processing other CAs
                 }
                 

--- a/Private/Set/Set-CAInterfaceFlags.ps1
+++ b/Private/Set/Set-CAInterfaceFlags.ps1
@@ -1,4 +1,4 @@
-﻿function Set-CAInterfaceFlags {
+function Set-CAInterfaceFlags {
     <#
         .SYNOPSIS
         Adds InterfaceFlags configuration properties to AD CS Certification Authority objects.
@@ -77,31 +77,38 @@
                 }
                 
                 Write-Verbose "  Querying InterfaceFlags for: $caFullName"
-                
+
+                $caObject = $_
                 try {
                     # Query InterfaceFlags using PSCertutil
                     $interfaceFlags = Get-PSCInterfaceFlag -CAFullName $caFullName -ErrorAction Stop
-                    
+
                     if ($interfaceFlags) {
                         Write-Verbose "  Retrieved $(@($interfaceFlags).Count) InterfaceFlags"
-                        
+
                         # Check specifically for IF_ENFORCEENCRYPTICERTREQUEST
                         $encryptionFlag = $interfaceFlags | Where-Object { $_.InterfaceFlag.ToString() -eq 'IF_ENFORCEENCRYPTICERTREQUEST' }
                         $rpcEncryptionNotRequired = if ($encryptionFlag) { -not $encryptionFlag.Enabled } else { $true }
-                        
+
                         Write-Verbose "  IF_ENFORCEENCRYPTICERTREQUEST is $(if ($rpcEncryptionNotRequired) { 'disabled or missing - RPC encryption not required' } else { 'enabled - RPC encryption required' })"
-                        
+
                         # Set properties directly on the LS2AdcsObject (same reference as store)
-                        $_.InterfaceFlags = $interfaceFlags
-                        $_.RPCEncryptionNotRequired = $rpcEncryptionNotRequired
-                        Write-Verbose "  Updated $($_.distinguishedName) with InterfaceFlags data"
-                        
+                        $caObject.InterfaceFlags = $interfaceFlags
+                        $caObject.RPCEncryptionNotRequired = $rpcEncryptionNotRequired
+                        Write-Verbose "  Updated $($caObject.distinguishedName) with InterfaceFlags data"
+
                     } else {
                         Write-Verbose "  No InterfaceFlags returned from Get-PSCInterfaceFlag"
+                        # Unknown state: leave tri-state properties $null so detection does not treat failure as clean
+                        $caObject.InterfaceFlags = $null
+                        $caObject.RPCEncryptionNotRequired = $null
                     }
-                    
+
                 } catch {
                     Write-Verbose "  Failed to query InterfaceFlags for '$caFullName': $($_.Exception.Message)"
+                    # Unknown state: leave tri-state properties $null so detection does not treat failure as clean
+                    $caObject.InterfaceFlags = $null
+                    $caObject.RPCEncryptionNotRequired = $null
                     # Continue processing other CAs
                 }
                 

--- a/Tests/Private/Set/Set-CAAuditFilter.Tests.ps1
+++ b/Tests/Private/Set/Set-CAAuditFilter.Tests.ps1
@@ -120,5 +120,31 @@ Describe 'Set-CAAuditFilter' -Tag 'Unit' {
                 $result.AuditingIncomplete | Should -BeTrue
             }
         }
+
+        Context 'Query failure must not produce an Auditing finding (GH #92)' {
+            It 'should set AuditingIncomplete to $null when Get-PSCAuditFilter throws' {
+                $ca = New-MockLS2AdcsObject -Properties @{
+                    objectClass     = @('top', 'pKIEnrollmentService')
+                    SchemaClassName = 'pKIEnrollmentService'
+                    CAFullName      = 'contoso.com\MyCA'
+                    cn              = 'MyCA'
+                }
+                Mock Get-PSCAuditFilter { throw 'certutil -getreg failed: RPC server unavailable' }
+                $result = $ca | Set-CAAuditFilter
+                $result.AuditingIncomplete | Should -BeNullOrEmpty
+            }
+
+            It 'should set AuditingIncomplete to $null when Get-PSCAuditFilter returns null' {
+                $ca = New-MockLS2AdcsObject -Properties @{
+                    objectClass     = @('top', 'pKIEnrollmentService')
+                    SchemaClassName = 'pKIEnrollmentService'
+                    CAFullName      = 'contoso.com\MyCA'
+                    cn              = 'MyCA'
+                }
+                Mock Get-PSCAuditFilter { $null }
+                $result = $ca | Set-CAAuditFilter
+                $result.AuditingIncomplete | Should -BeNullOrEmpty
+            }
+        }
     }
 }

--- a/Tests/Private/Set/Set-CADisableExtensionList.Tests.ps1
+++ b/Tests/Private/Set/Set-CADisableExtensionList.Tests.ps1
@@ -12,6 +12,13 @@ BeforeAll {
 
 Describe 'Set-CADisableExtensionList' -Tag 'Unit' {
     InModuleScope 'Locksmith2' {
+        BeforeAll {
+            # Stub Get-PSCDisableExtensionList so Pester can mock it even when PSCertutil is not loaded
+            if (-not (Get-Command Get-PSCDisableExtensionList -ErrorAction SilentlyContinue)) {
+                function script:Get-PSCDisableExtensionList { param([string]$CAFullName) $null }
+            }
+        }
+
         BeforeEach {
             $script:IssueStore = @{}; $script:PrincipalStore = @{}; $script:AdcsObjectStore = @{}
             $script:DomainStore = @{}; $script:SafePrincipals = @(); $script:DangerousPrincipals = @()
@@ -109,6 +116,20 @@ Describe 'Set-CADisableExtensionList' -Tag 'Unit' {
                 Mock Get-PSCDisableExtensionList { @() } -ParameterFilter { $CAFullName -eq 'contoso.com\MyCA' }
                 $null = $ca | Set-CADisableExtensionList
                 Should -Invoke Get-PSCDisableExtensionList -Times 1 -Exactly -ParameterFilter { $CAFullName -eq 'contoso.com\MyCA' }
+            }
+        }
+
+        Context 'Query failure must not produce an ESC16 finding (GH #92 pattern)' {
+            It 'should set SecurityExtensionDisabled to $null when Get-PSCDisableExtensionList throws' {
+                $ca = New-MockLS2AdcsObject -Properties @{
+                    objectClass     = @('top', 'pKIEnrollmentService')
+                    SchemaClassName = 'pKIEnrollmentService'
+                    CAFullName      = 'contoso.com\MyCA'
+                    cn              = 'MyCA'
+                }
+                Mock Get-PSCDisableExtensionList { throw 'certutil -getreg failed: RPC server unavailable' }
+                $result = $ca | Set-CADisableExtensionList
+                $result.SecurityExtensionDisabled | Should -BeNullOrEmpty
             }
         }
     }

--- a/Tests/Private/Set/Set-CAEditFlags.Tests.ps1
+++ b/Tests/Private/Set/Set-CAEditFlags.Tests.ps1
@@ -105,5 +105,31 @@ Describe 'Set-CAEditFlags' -Tag 'Unit' {
                 Should -Invoke Get-PSCEditFlag -Times 1 -Exactly -ParameterFilter { $CAFullName -eq 'contoso.com\MyCA' }
             }
         }
+
+        Context 'Query failure must not produce an ESC6 finding (GH #92 pattern)' {
+            It 'should set SANFlagEnabled to $null when Get-PSCEditFlag throws' {
+                $ca = New-MockLS2AdcsObject -Properties @{
+                    objectClass     = @('top', 'pKIEnrollmentService')
+                    SchemaClassName = 'pKIEnrollmentService'
+                    CAFullName      = 'contoso.com\MyCA'
+                    cn              = 'MyCA'
+                }
+                Mock Get-PSCEditFlag { throw 'certutil -getreg failed: RPC server unavailable' }
+                $result = $ca | Set-CAEditFlags
+                $result.SANFlagEnabled | Should -BeNullOrEmpty
+            }
+
+            It 'should set SANFlagEnabled to $null when Get-PSCEditFlag returns no results' {
+                $ca = New-MockLS2AdcsObject -Properties @{
+                    objectClass     = @('top', 'pKIEnrollmentService')
+                    SchemaClassName = 'pKIEnrollmentService'
+                    CAFullName      = 'contoso.com\MyCA'
+                    cn              = 'MyCA'
+                }
+                Mock Get-PSCEditFlag { $null }
+                $result = $ca | Set-CAEditFlags
+                $result.SANFlagEnabled | Should -BeNullOrEmpty
+            }
+        }
     }
 }

--- a/Tests/Private/Set/Set-CAInterfaceFlags.Tests.ps1
+++ b/Tests/Private/Set/Set-CAInterfaceFlags.Tests.ps1
@@ -103,5 +103,31 @@ Describe 'Set-CAInterfaceFlags' -Tag 'Unit' {
                 Should -Invoke Get-PSCInterfaceFlag -Times 1 -Exactly -ParameterFilter { $CAFullName -eq 'contoso.com\MyCA' }
             }
         }
+
+        Context 'Query failure must not produce an ESC11 finding (GH #92 pattern)' {
+            It 'should set RPCEncryptionNotRequired to $null when Get-PSCInterfaceFlag throws' {
+                $ca = New-MockLS2AdcsObject -Properties @{
+                    objectClass     = @('top', 'pKIEnrollmentService')
+                    SchemaClassName = 'pKIEnrollmentService'
+                    CAFullName      = 'contoso.com\MyCA'
+                    cn              = 'MyCA'
+                }
+                Mock Get-PSCInterfaceFlag { throw 'certutil -getreg failed: RPC server unavailable' }
+                $result = $ca | Set-CAInterfaceFlags
+                $result.RPCEncryptionNotRequired | Should -BeNullOrEmpty
+            }
+
+            It 'should set RPCEncryptionNotRequired to $null when Get-PSCInterfaceFlag returns no results' {
+                $ca = New-MockLS2AdcsObject -Properties @{
+                    objectClass     = @('top', 'pKIEnrollmentService')
+                    SchemaClassName = 'pKIEnrollmentService'
+                    CAFullName      = 'contoso.com\MyCA'
+                    cn              = 'MyCA'
+                }
+                Mock Get-PSCInterfaceFlag { $null }
+                $result = $ca | Set-CAInterfaceFlags
+                $result.RPCEncryptionNotRequired | Should -BeNullOrEmpty
+            }
+        }
     }
 }

--- a/Tests/Public/Find-LS2VulnerableCA.Tests.ps1
+++ b/Tests/Public/Find-LS2VulnerableCA.Tests.ps1
@@ -374,6 +374,23 @@ InModuleScope 'Locksmith2' {
                 $result.Count | Should -Be 0
             }
 
+            It 'should not return an issue when AuditingIncomplete is $null (query failed — GH #92)' {
+                $unknownCA = New-MockLS2AdcsObject -Properties @{
+                    objectClass        = @('top', 'pKIEnrollmentService')
+                    SchemaClassName    = 'pKIEnrollmentService'
+                    CAFullName         = 'CONTOSO\UnreachableCA'
+                    cn                 = 'UnreachableCA'
+                    AuditingIncomplete = $null
+                    AuditFilter        = $null
+                    distinguishedName  = 'CN=UnreachableCA,...'
+                }
+                $script:AdcsObjectStore = @{ $unknownCA.distinguishedName = $unknownCA }
+
+                $result = @(Find-LS2VulnerableCA -Technique 'Auditing')
+
+                $result.Count | Should -Be 0
+            }
+
             It 'should return nothing when Initialize-LS2Scan returns false' {
                 Mock 'Initialize-LS2Scan' { $false }
                 $result = @(Find-LS2VulnerableCA -Technique 'Auditing')

--- a/Tests/Shared/TestHelpers.psm1
+++ b/Tests/Shared/TestHelpers.psm1
@@ -106,7 +106,7 @@ function New-MockLS2AdcsObject {
     $obj.SANFlagEnabled           = $null
     $obj.InterfaceFlags           = @()
     $obj.AuditFilter              = $null
-    $obj.AuditingIncomplete       = $false
+    $obj.AuditingIncomplete       = $null
     $obj.DisableExtensionList     = @()
     $obj.SecurityExtensionDisabled = $null
     $obj.HasLinkedGroupOIDPolicy  = $null


### PR DESCRIPTION
fix(detection): tri-state certutil-backed CA properties so query failure is not a finding

Closes #92, together with jakehildreth/PSCertutil#2.

## Root cause (two layers)

1. **PSCertutil (the actual trigger):** `parseAuditFilter` ran `[int]$AuditFilter = $null` on certutil failure, coercing `$null` to `0`, then always emitted `@{ AuditFilter = 0 }`. A failed `-getreg CA\AuditFilter` returned a real `0`, so Locksmith2 computed `AuditingIncomplete = (0 -ne 127) = $true` → "auditing not enabled" on a query failure. Fixed in jakehildreth/PSCertutil#2 (parser now emits nothing on parse failure).

2. **Locksmith2 (the design gap, this PR):** the four certutil-backed detection properties had no "unknown" state. `AuditingIncomplete` was a non-nullable `[bool]`, so a failed/absent query was indistinguishable from "queried, clean." Defense-in-depth even with a fixed parser.

## What changed

- `Classes/LS2AdcsObject.ps1`: `AuditingIncomplete` → `[Nullable[bool]]`; `$null` = unknown/never queried.
- All four `Set-CA*` cmdlets (`AuditFilter`, `EditFlags`, `InterfaceFlags`, `DisableExtensionList`): set their detection properties to `$null` on both throw and empty-result paths, so failure is never clean and a stale rescan value cannot survive.
- Fixed `Set-CADisableExtensionList` catch block: it set properties on `$_` (the ErrorRecord inside `catch`), so the failure path had never worked.
- Tests: failure-path contexts (throw + null-result) in all four `Set-CA*` suites, PSCertutil stub for `Set-CADisableExtensionList`, Find-level regression proving a CA with `AuditingIncomplete = $null` emits no `Auditing` issue.

## Verification

- 56/56 targeted tests pass in pwsh 7.6.5.
- Full suite: 238 pre-existing macOS platform failures, identical on unmodified `main` (no Windows Principal/`System.DirectoryServices` APIs); zero new failures.
- PS 5.1 leg pending — must run on Windows (`powershell.exe`) before merge.

## Not in this change

- PSCertutil fix lands in its own repo/PR (jakehildreth/PSCertutil#2).
- "Unknown" state surfaces only at `-Verbose`; a visible warning/dashboard state is possible follow-up, deliberately out of scope.
